### PR TITLE
LIME-369: Adding steps to incorporate tests in the aws pipeline

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -74,6 +74,30 @@ jobs:
         working-directory: ./infrastructure/lambda/
         run: sam build
 
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.9.0'
+
+      - name: Build, tag, and push testing images to Amazon ECR
+        env:
+          CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY_BUILD: ${{ secrets.ECR_REPOSITORY_BUILD }}
+          ECR_REPOSITORY_STAGING: ${{ secrets.ECR_REPOSITORY_STAGING }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG acceptance-tests
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG
+          cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
+          cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
+
       - name: Deploy SAM app
         uses: alphagov/di-devplatform-upload-action@v3
         with:


### PR DESCRIPTION
## Proposed changes

### What changed

Added github action to push tests into pipeline

### Why did it change

To allow testing within the secure pipelines
