### PR TITLE
LIME-832 VC/Audit Event Update - ciReasons and checkDetails/failedCheckDetails

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,33 +99,18 @@ See onboarding guide for instructions on how to setup the following command line
 - aws cli
 - aws-vault
 - sam cli
-- gds cli
 
 ### Deploy to passport dev account
 
-`gds aws di-ipv-cri-passporta-dev-admin -- ./deploy.sh di-ipv-cri-passport-myusernameORticket`
+`aws-vault exec pa-dev -- ./deploy.sh ipv-cri-passport-MyUsernameOrTicketNumber`
 
 ### Delete stack from passport dev account
-> The stack name *must* be unique to you and created by you in the deploy stage above.
-> Type `y`es when prompted to delete the stack and the folders in S3 bucket
+> The stack name *must* be unique to you and created by you in the deploy step above.
+> Type `y`es when prompted to delete the stack and the folders in the S3 bucket
 
 The command to run is:
 
-`gds aws di-ipv-cri-passporta-dev-admin -- sam delete --config-env dev --stack-name di-ipv-cri-passport-myusernameORticket`
-
-### Deploy to shared dev account
-
-edit deploy.sh and set DevEnvironment=cri-dev
-
-`gds aws di-ipv-cri-dev -- ./deploy.sh di-ipv-cri-passport-myusernameORticket`
-
-### Delete stack from shared dev account
-> The stack name *must* be unique to you and created by you in the deploy stage above.
-> Type `y`es when prompted to delete the stack and the folders in S3 bucket
-
-The command to run is:
-
-`gds aws ROLE -- sam delete --config-env dev --stack-name <unique-stack-name>`
+`aws-vault exec pa-dev -- sam delete --stack-name ipv-cri-passport-MyUsernameOrTicketNumber`
 
 ### Parameter prefix
 
@@ -139,6 +124,13 @@ Can also be used with the following limitations in development.
 - Existing stack needs to have all the parameters needed for the stack with the prefix enabled.
 - Existing stack parameters values if changed will trigger behaviour changes in the stack with the prefix enabled.
 - Existing stack if deleted will cause errors in the deployed stack.
+
+## Testing with self deployed stub
+If testing against a self deployed stub in the passporta dev environment.
+The domain used by the stubs lambda function url will need added to
+- The dns firewall allowed domains list
+- A new rule added to the network firewall suricata rules config
+  This will enable your deployed stack to connect to your deployed stub.
 
 ## Acceptance Test
 

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportAPIStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportAPIStepDefs.java
@@ -8,6 +8,7 @@ import uk.gov.di.ipv.cri.passport.acceptance_tests.pages.PassportAPIPage;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 
 public class PassportAPIStepDefs extends PassportAPIPage {
@@ -31,20 +32,19 @@ public class PassportAPIStepDefs extends PassportAPIPage {
         getSessionIdForPassport();
     }
 
-    @When(
-            "Passport user sends a POST request to Passport endpoint using jsonRequest (.*) and document checking route is (.*)$")
+    @When("Passport user sends a POST request to Passport endpoint using jsonRequest (.*)$")
     public void passport_user_sends_a_post_request_to_passport_end_point(
-            String passportJsonRequestBody, String documentCheckingRoute)
+            String passportJsonRequestBody)
             throws IOException, InterruptedException, NoSuchFieldException, IllegalAccessException {
-        postRequestToPassportEndpoint(passportJsonRequestBody, documentCheckingRoute);
+        postRequestToPassportEndpoint(passportJsonRequestBody);
     }
 
     @When(
-            "Passport user sends a editable POST request to Passport endpoint using jsonRequest (.*) with edited fields (.*) and document checking route is (.*)$")
+            "Passport user sends a editable POST request to Passport endpoint using jsonRequest (.*) with edited fields (.*)$")
     public void passport_user_sends_a_post_request_to_passport_end_point(
-            String passportJsonRequestBody, String jsonEdits, String documentCheckingRoute)
+            String passportJsonRequestBody, String jsonEdits)
             throws IOException, InterruptedException, NoSuchFieldException, IllegalAccessException {
-        postRequestToPassportEndpoint(passportJsonRequestBody, jsonEdits, documentCheckingRoute);
+        postRequestToPassportEndpoint(passportJsonRequestBody, jsonEdits);
     }
 
     @And("Passport check response should contain Retry value as (.*)$")
@@ -72,27 +72,26 @@ public class PassportAPIStepDefs extends PassportAPIPage {
     @And("Passport VC should contain validityScore (.*) and strengthScore (.*)$")
     public void passport_vc_should_contain_validity_score_and_strength_score(
             String validityScore, String strengthScore)
-            throws IOException, InterruptedException, ParseException, URISyntaxException {
+            throws IOException, InterruptedException, ParseException {
         validityScoreAndStrengthScoreInVC(validityScore, strengthScore);
     }
 
     @And("Passport VC should contain ci (.*), validityScore (.*) and strengthScore (.*)$")
     public void passport_vc_should_contain_ci_validity_score_and_strength_score(
             String ci, String validityScore, String strengthScore)
-            throws IOException, InterruptedException, ParseException, URISyntaxException {
+            throws IOException, InterruptedException, ParseException {
         ciInPassportCriVc(ci);
         validityScoreAndStrengthScoreInVC(validityScore, strengthScore);
     }
 
-    @And("Passport VC should contain (.*) checkDetails$")
-    public void passport_vc_should_contain_check_details(String checkDetailsType)
-            throws IOException, InterruptedException, ParseException, URISyntaxException {
-        assertCheckDetails(checkDetailsType);
+    @And("Passport VC Evidence contains expected values for scenario (.*)$")
+    public void passport_vc_should_contain_evidence_for_scenario(int scenario)
+            throws IOException, NoSuchAlgorithmException {
+        assertVCEvidence(scenario);
     }
 
     @And("Check response contains unexpected server error exception")
-    public void passport_check_fails_and_returns_unexpected_exception()
-            throws IOException, InterruptedException, ParseException, URISyntaxException {
+    public void passport_check_fails_and_returns_unexpected_exception() {
         checkPassportResponseContainsException();
     }
 }

--- a/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
@@ -1,76 +1,57 @@
 @passport_CRI_API
 Feature: Passport CRI API
 
-  @passportCRI_API @pre-merge @dev
-  Scenario Outline: Create call to auth token from Passport CRI when document checking route is not provided or is invalid
+  @hmpoDVAD @passportCRI_API @pre-merge @dev
+  Scenario: Passport Journey Happy Path
     Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
-    When Passport user sends a POST request to Passport endpoint using jsonRequest <PassportJsonPayload> and document checking route is <Invalid>
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidKennethJsonPayload
     And Passport user gets authorisation code
     And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
     Then User requests Passport CRI VC
     And Passport VC should contain validityScore 2 and strengthScore 4
-    And Passport VC should contain success checkDetails
-    Examples:
-      |PassportJsonPayload                   |     Invalid         |
-      |PassportValidKennethJsonPayload       |       ABCD          |
-      |PassportValidKennethJsonPayload       |  not-provided       |
+    And Passport VC Evidence contains expected values for scenario 1
 
-#########  hmpoDVAD tests ##########
   @hmpoDVAD @passportCRI_API @pre-merge @dev
-  Scenario: Create call to auth token from Passport CRI with dvad as document checking route
+  Scenario: Passport Retry Journey Happy Path
     Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
-    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidKennethJsonPayload and document checking route is dvad
-    And Passport user gets authorisation code
-    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
-    Then User requests Passport CRI VC
-    And Passport VC should contain validityScore 2 and strengthScore 4
-    And Passport VC should contain success checkDetails
-
-  @hmpoDVAD @passportCRI_API @pre-merge @dev
-  Scenario: Passport Retry Journey Happy Path with dvad as document checking route
-    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
-    And Passport user sends a POST request to session endpoint
-    And Passport user gets a session-id
-    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportInvalidJsonPayload and document checking route is dvad
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportInvalidJsonPayload
     Then Passport check response should contain Retry value as true
-    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidKennethJsonPayload and document checking route is dvad
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidKennethJsonPayload
     And Passport user gets authorisation code
     And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
     Then User requests Passport CRI VC
     And Passport VC should contain validityScore 2 and strengthScore 4
-    And Passport VC should contain success checkDetails
+    And Passport VC Evidence contains expected values for scenario 1
 
   @hmpoDVAD @passportCRI_API @pre-merge @dev
-  Scenario: Passport user fails first attempt with dvad as document checking route but VC is still created
+  Scenario: Passport user fails first attempt and VC is created for prove another way route
     Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
-    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportInvalidJsonPayload and document checking route is dvad
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportInvalidJsonPayload
     Then Passport check response should contain Retry value as true
     And Passport user gets authorisation code
     And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
     Then User requests Passport CRI VC
     And Passport VC should contain ci D02, validityScore 0 and strengthScore 4
-    And Passport VC should contain failed checkDetails
+    And Passport VC Evidence contains expected values for scenario 2
 
-#  Bug LIME-776 raised to fix the validity score
   @hmpoDVAD @passportCRI_API @pre-merge @dev
   Scenario Outline: Create call to auth token from Passport CRI with dvad as document checking route and test CI scenarios
     Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
     And Passport user sends a POST request to session endpoint
     And Passport user gets a session-id
-    When Passport user sends a POST request to Passport endpoint using jsonRequest <PassportJsonPayload> and document checking route is dvad
+    When Passport user sends a POST request to Passport endpoint using jsonRequest <PassportJsonPayload>
     And Passport user gets authorisation code
     And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
     Then User requests Passport CRI VC
     And Passport VC should contain ci <CI>, validityScore 0 and strengthScore 4
-    And Passport VC should contain <checkDetails> checkDetails
+    And Passport VC Evidence contains expected values for scenario <Scenario>
     Examples:
-      |PassportJsonPayload              | CI  | checkDetails |
-      |PassportInvalidCI1JsonPayload    | D01 |  failed            |
-      |PassportInvalidCI2JsonPayload    | D01 |  failed            |
-      |PassportInvalidJsonPayload       | D02 |  failed            |
+      |PassportJsonPayload              | CI  |  Scenario |
+      |PassportInvalidCI1JsonPayload    | D01 |  3        |
+      |PassportInvalidCI2JsonPayload    | D01 |  4        |

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/domain/result/DocumentDataVerificationResult.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/domain/result/DocumentDataVerificationResult.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.passport.checkpassport.domain.result;
 
+import lombok.Getter;
 import uk.gov.di.ipv.cri.passport.checkpassport.domain.result.fields.APIResultSource;
 
 import java.util.ArrayList;
@@ -17,7 +18,8 @@ public class DocumentDataVerificationResult {
     private String transactionId;
 
     private List<String> checksSucceeded = new ArrayList<>();
-    private List<String> checksFailed = new ArrayList<>();
+    @Getter private List<String> checksFailed = new ArrayList<>();
+    private List<String> contraIndicatorReasons = new ArrayList<>();
 
     public APIResultSource getAPIResultSource() {
         return apiResultSource;
@@ -75,11 +77,15 @@ public class DocumentDataVerificationResult {
         this.checksSucceeded = checksSucceeded;
     }
 
-    public List<String> getChecksFailed() {
-        return checksFailed;
-    }
-
     public void setChecksFailed(List<String> checksFailed) {
         this.checksFailed = checksFailed;
+    }
+
+    public void setContraIndicatorReasons(List<String> contraIndicatorReasons) {
+        this.contraIndicatorReasons = contraIndicatorReasons;
+    }
+
+    public List<String> getContraIndicatorReasons() {
+        return contraIndicatorReasons;
     }
 }

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/domain/result/fields/ContraIndicatorMapperResult.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/domain/result/fields/ContraIndicatorMapperResult.java
@@ -1,0 +1,20 @@
+package uk.gov.di.ipv.cri.passport.checkpassport.domain.result.fields;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+public class ContraIndicatorMapperResult {
+    // Prevent these from ever being null
+    @Builder.Default private List<String> contraIndicators = new ArrayList<>();
+
+    @Builder.Default private List<String> contraIndicatorReasons = new ArrayList<>();
+
+    @Builder.Default private List<String> contraIndicatorChecks = new ArrayList<>();
+
+    @Builder.Default private List<String> contraIndicatorFailedChecks = new ArrayList<>();
+}

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
@@ -56,9 +56,6 @@ public class CheckPassportHandler
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    // Header Keys
-    public static final String HEADER_DOCUMENT_CHECKING_ROUTE = "document-checking-route";
-
     // Return values for retry scenario
     public static final String RESULT = "result";
     public static final String RESULT_RETRY = "retry";
@@ -166,8 +163,7 @@ public class CheckPassportHandler
             PassportFormData passportFormData = parsePassportFormRequest(input.getBody());
             eventProbe.counterMetric(FORM_DATA_PARSE_PASS);
 
-            // Dynamic Third party API selection based on new-api header key being present (value
-            // ignored)
+            // Dynamic Third party API selection based on feature toggle
             boolean dvaDigitalEnabled =
                     Boolean.parseBoolean(
                             passportConfigurationService.getStackParameterValue(
@@ -383,7 +379,6 @@ public class CheckPassportHandler
     }
 
     private ThirdPartyAPIService selectThirdPartyAPIService(boolean dvaDigitalEnabled) {
-        // Feature flag and header required for new api
         if (dvaDigitalEnabled) {
             // DVAD
             return thirdPartyAPIServiceFactory.getDvadThirdPartyAPIService();
@@ -402,8 +397,12 @@ public class CheckPassportHandler
         documentCheckResultItem.setSessionId(sessionItem.getSessionId());
 
         documentCheckResultItem.setTransactionId(documentDataVerificationResult.getTransactionId());
+
         documentCheckResultItem.setContraIndicators(
                 documentDataVerificationResult.getContraIndicators());
+        documentCheckResultItem.setCiReasons(
+                documentDataVerificationResult.getContraIndicatorReasons());
+
         documentCheckResultItem.setStrengthScore(documentDataVerificationResult.getStrengthScore());
         documentCheckResultItem.setValidityScore(documentDataVerificationResult.getValidityScore());
 

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ContraIndicatorComplexMapping.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ContraIndicatorComplexMapping.java
@@ -46,4 +46,8 @@ public final class ContraIndicatorComplexMapping {
     private String titleToSnakeCase(String flag) {
         return flag.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase();
     }
+
+    public String getRequiredFlagValue() {
+        return requiredFlagValue;
+    }
 }

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ContraIndicatorComplexMapping.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ContraIndicatorComplexMapping.java
@@ -1,12 +1,49 @@
 package uk.gov.di.ipv.cri.passport.checkpassport.services;
 
+import lombok.Data;
+
+@Data
 public final class ContraIndicatorComplexMapping {
 
+    private static final String ERROR_FORMAT = "Flag %s not in the expected camel case format";
+
     public final String ci;
+    public final String reason;
+    public final String check;
+
     public final String requiredFlagValue;
 
-    public ContraIndicatorComplexMapping(String ci, String requiredFlagValue) {
+    public ContraIndicatorComplexMapping(String ci, String flag, String requiredFlagValue) {
         this.ci = ci;
+
+        // assumes flag is camelCaseFormat - becoming CaseFormat
+        String flagMinusPrefix = removeFlagPrefix(flag);
+
+        this.reason = flagMinusPrefix;
+        this.check = titleToSnakeCase(flagMinusPrefix) + "_check";
         this.requiredFlagValue = requiredFlagValue;
+    }
+
+    private String removeFlagPrefix(String flag) {
+
+        int location = -1;
+        for (int c = 0; c < flag.length(); c++) {
+            if (Character.isUpperCase(flag.charAt(c))) {
+                location = c;
+                break;
+            }
+        }
+
+        // Not -1 or 0 (first char)
+        if (location >= 1) {
+            return flag.substring(location);
+        } else {
+            String message = String.format(ERROR_FORMAT, flag);
+            throw new IllegalStateException(message);
+        }
+    }
+
+    private String titleToSnakeCase(String flag) {
+        return flag.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase();
     }
 }

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ContraIndicatorMapper.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ContraIndicatorMapper.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.passport.checkpassport.services;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.passport.checkpassport.domain.result.fields.ContraIndicatorMapperResult;
 import uk.gov.di.ipv.cri.passport.library.service.PassportConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.service.ServiceFactory;
 
@@ -16,22 +17,31 @@ import java.util.stream.Collectors;
 
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.CONTRAINDICATION_MAPPINGS;
 
-/**
- * Originally added to map values from sensitive fields from an earlier DVAD API spec. Left as a
- * similar CI mapping maybe needed in-future.
- */
+/** Flags in the CI_MAP are sensitive fields. */
 public class ContraIndicatorMapper {
     private static final String MAPPING_DELIMITER = "\\|\\|"; // "||" (escaped)
     private static final String FLAGS_CI_DELIMITER = ":";
-    private static final String FLAGS_DELIMITER = ",";
+    private static final String FLAGS_STANDARD_DELIMITER = ",";
+    private static final String FLAGS_WITH_CI_REASON_SUB_SET_DELIMITER = ">";
     private static final String FLAG_VALUE_DELIMITER = "@";
+
+    // CI:Reason
+    private static final String CI_REASON_FORMAT = "%s,%s";
 
     private static final String CI_MAP = "CIMap";
 
     // Non-static as Log-line output in this class is tested
     private final Logger logger = LogManager.getLogger();
 
-    private final Map<String, ContraIndicatorComplexMapping> flagCIMap;
+    // Indexed by Flag
+    private final Map<String, ContraIndicatorComplexMapping> flagToContraIndicatorMappings =
+            new HashMap<>();
+
+    // If a reason is present also its more specific subset reason,
+    // Then we only want the specific reason to appear in the result
+    // Map Indexed by specific subset reason
+    private final Map<String, ContraIndicatorComplexMapping> ciReasonSubSetMappings =
+            new HashMap<>();
 
     public ContraIndicatorMapper(ServiceFactory serviceFactory) {
 
@@ -43,25 +53,30 @@ public class ContraIndicatorMapper {
                         ? passportConfigurationService.getParameterValue(CONTRAINDICATION_MAPPINGS)
                         : System.getenv().get(CI_MAP);
 
-        flagCIMap = parseCIMappingString(contraindicatorMappingString);
+        parseCIMappingStringAndPopulateMappings(contraindicatorMappingString);
 
-        logger.info("CI Mappings ({})", flagCIMap.size());
+        logger.info("CI Mappings ({})", flagToContraIndicatorMappings.size());
+        logger.info("CI Reason Subset Mappings ({})", ciReasonSubSetMappings.size());
     }
 
     /**
-     * Parses a string representing the flag Mappings. Example :
-     * CIMap=flag1@true,flag2@false:a1||flag3@40:b1 Represents : flag1:true -> a1 flag2:false -> a1
-     * flag3:40 -> b1 where flag1 triggers if true, flag2 triggers if false Assumes we never map
-     * flag to a second CICode.
+     * Parses a string representing the flag Mappings.
+     *
+     * <pre>
+     * Example Mapping : CIMap=flag1@true,flag2@false:a1||flag3@40:b1||flag4@true>flag5@true:c1
+     * Example Format  : flag1@true,flag2@false:a1 - flag1 triggers if true, flag2 triggers if false CI is a1
+     * Example Format  : flag3@40,flag2@false:a1   - flag3 triggers if value is 40 CI is b1
+     * Example Format  : flag4@true>flag5@true:c1  - flag4 and flag5 trigger if true, if both trigger only the reason
+     * for flag4 is used, as flag 5 is the general flag.
+     * </pre>
+     *
+     * Assumes we never map the same flag to a second CICode.
      *
      * @param mappingString String with the mappings in above syntax
-     * @return A map of flags to CI pairs
      */
-    private Map<String, ContraIndicatorComplexMapping> parseCIMappingString(String mappingString) {
+    private void parseCIMappingStringAndPopulateMappings(String mappingString) {
 
         logger.info("Parsing CI mapping string...");
-
-        Map<String, ContraIndicatorComplexMapping> tempflagCIMap = new HashMap<>();
 
         String[] mappings = mappingString.split(MAPPING_DELIMITER);
 
@@ -69,9 +84,22 @@ public class ContraIndicatorMapper {
 
             List<String> flagCIPairs = Arrays.asList(mapping.split(FLAGS_CI_DELIMITER));
 
-            String[] flagNameValuePairs = flagCIPairs.get(0).split(FLAGS_DELIMITER);
+            // Once set, this is used for the entire flag
+            // using multiple delimiters for a single CI not supported
+            boolean isCiReasonSubsetMapping =
+                    flagCIPairs.get(0).contains(FLAGS_WITH_CI_REASON_SUB_SET_DELIMITER);
+
+            final String ciPairDelimiter;
+            if (isCiReasonSubsetMapping) {
+                ciPairDelimiter = FLAGS_WITH_CI_REASON_SUB_SET_DELIMITER;
+            } else {
+                ciPairDelimiter = FLAGS_STANDARD_DELIMITER;
+            }
+
+            String[] flagNameValuePairs = flagCIPairs.get(0).split(ciPairDelimiter);
             String ciCode = flagCIPairs.get(1);
 
+            List<ContraIndicatorComplexMapping> ciReasonsMappingAccumulator = new ArrayList<>();
             for (String flagNameValuePair : flagNameValuePairs) {
 
                 String[] flagNameValuePairSplit = flagNameValuePair.split(FLAG_VALUE_DELIMITER);
@@ -81,73 +109,73 @@ public class ContraIndicatorMapper {
                 String requiredValue = flagNameValuePairSplit[1];
 
                 ContraIndicatorComplexMapping complexMapping =
-                        new ContraIndicatorComplexMapping(ciCode, requiredValue);
+                        new ContraIndicatorComplexMapping(ciCode, flagName, requiredValue);
 
-                tempflagCIMap.put(flagName, complexMapping);
+                ciReasonsMappingAccumulator.add(complexMapping);
+
+                flagToContraIndicatorMappings.put(flagName, complexMapping);
+            }
+
+            if (isCiReasonSubsetMapping) {
+                int ciReasonsSize = ciReasonsMappingAccumulator.size();
+                // Remove the last mapping as it is the general reason
+                ContraIndicatorComplexMapping generalMapping =
+                        ciReasonsMappingAccumulator.remove(ciReasonsSize - 1);
+
+                for (ContraIndicatorComplexMapping specificMapping : ciReasonsMappingAccumulator) {
+                    // Add the override for the general mapping to specific reason (mapping used as
+                    // the CI is needed later)
+                    // Can handle multiple overrides in the same mapping
+                    ciReasonSubSetMappings.put(specificMapping.getReason(), generalMapping);
+                }
             }
         }
-
-        return tempflagCIMap;
     }
 
-    public List<String> mapFlagsToCIs(Map<String, String> flagMap) {
+    public ContraIndicatorMapperResult mapFlagsToCIs(Map<String, String> flagMap) {
         Objects.requireNonNull(flagMap, "flagMap must not be null");
 
         if (flagMap.isEmpty()) {
             logger.info("No flags to map");
-            return new ArrayList<>();
+            return ContraIndicatorMapperResult.builder().build();
         }
 
-        List<String> contraIndicators =
+        // Flag must be present and matching the required flag value
+        List<ContraIndicatorComplexMapping> matchingCiMappings =
                 flagMap.keySet().stream()
-                        .filter(flagCIMap::containsKey)
-                        .filter(
-                                flag -> {
-                                    // Flag must be present and matching the required flag value
-                                    String filterValue = flagCIMap.get(flag).requiredFlagValue;
-                                    String flagValue = flagMap.get(flag);
-
-                                    return filterValue.equals(flagValue);
-                                })
-                        .map(flag -> this.flagCIMap.get(flag).ci)
+                        .filter(flagToContraIndicatorMappings::containsKey)
+                        .filter(flag -> ciMapFilter(flagMap, flag))
+                        .map(flagToContraIndicatorMappings::get)
                         .collect(Collectors.toList());
 
-        List<String> presentNotMatching =
-                flagMap.keySet().stream()
-                        .filter(flagCIMap::containsKey)
-                        .filter(
-                                flag -> {
-                                    // Flag must be present and NOT matching the required flag value
-                                    String filterValue = flagCIMap.get(flag).requiredFlagValue;
-                                    String flagValue = flagMap.get(flag);
+        int flagsPresentAndMatching = matchingCiMappings.size();
+        logger.info("ContraIndicatorsFound ({})", flagsPresentAndMatching);
 
-                                    return !filterValue.equals(flagValue);
-                                })
+        // Flag must be present and NOT matching the required flag value
+        List<ContraIndicatorComplexMapping> presentNotMatchingCiMappings =
+                flagMap.keySet().stream()
+                        .filter(flagToContraIndicatorMappings::containsKey)
+                        .filter(flag -> !ciMapFilter(flagMap, flag)) // NOT
+                        .map(flagToContraIndicatorMappings::get)
                         .collect(Collectors.toList());
 
-        logger.info("PresentNotMatching ({})", presentNotMatching.size());
-        logger.debug(
-                "PresentNotMatching : {}",
-                !presentNotMatching.isEmpty() ? String.join(", ", presentNotMatching) : "[]");
-
-        int flagsInitialQuery = flagMap.size();
-        int flagPresentNotMatching = presentNotMatching.size();
-
-        int contraIndicatorsFound = contraIndicators.size();
-        logger.debug(
-                "ContraIndicators : {}",
-                !contraIndicators.isEmpty() ? String.join(", ", contraIndicators) : "[]");
+        int flagPresentNotMatching = presentNotMatchingCiMappings.size();
+        logger.info("PresentNotMatching ({})", flagPresentNotMatching);
 
         // ContraIndicators+flagPresentNotMatching must equal the flagMap size
         // If not, then the mappingString needs updated with the flags
+        // Or there is a mistake in the mapping string
+        int flagsInitialQuery = flagMap.size();
         boolean hasUnmappedFlags =
-                (flagsInitialQuery != (flagPresentNotMatching + contraIndicatorsFound));
+                (flagsInitialQuery != (flagPresentNotMatching + flagsPresentAndMatching));
 
         if (hasUnmappedFlags) {
-
             String[] unmappedFlags =
                     flagMap.keySet().stream()
-                            .filter(flag -> !flagCIMap.containsKey(flag)) // Not present
+                            .filter(
+                                    flag ->
+                                            !flagToContraIndicatorMappings.containsKey(
+                                                    flag)) // Not present
                             .toArray(String[]::new);
 
             String unmappedFlagsAsString = String.join(", ", unmappedFlags);
@@ -155,6 +183,83 @@ public class ContraIndicatorMapper {
         }
 
         // contraIndicators list is put through a set to remove duplicate CI's
-        return new ArrayList<>(Set.copyOf(contraIndicators));
+        List<String> contraIndicators =
+                matchingCiMappings.stream()
+                        .map(ContraIndicatorComplexMapping::getCi)
+                        .collect(Collectors.toList());
+        List<String> deDuplicatedContraIndicators = new ArrayList<>(Set.copyOf(contraIndicators));
+
+        // "Ci,Reason" pair for ciReasons array (will be split in vc evidence)
+        List<String> matchingCiReasons =
+                matchingCiMappings.stream()
+                        .map(
+                                value ->
+                                        String.format(
+                                                CI_REASON_FORMAT, value.getCi(), value.getReason()))
+                        .collect(Collectors.toList());
+
+        // Apply CI reasons subset mapping rules
+        List<String> specificReasons = new ArrayList<>(ciReasonSubSetMappings.keySet());
+
+        // List used for reasonsToFilter in-case of multiple subsets of a general reason
+        List<String> reasonsToFilter = new ArrayList<>();
+        for (String specificReason : specificReasons) {
+
+            ContraIndicatorComplexMapping generalMapping =
+                    ciReasonSubSetMappings.get(specificReason);
+
+            String ciSpecificReason =
+                    String.format(CI_REASON_FORMAT, generalMapping.getCi(), specificReason);
+
+            String ciGeneralReasonToFilterOut =
+                    String.format(
+                            CI_REASON_FORMAT, generalMapping.getCi(), generalMapping.getReason());
+
+            // The final step is to only mark the general reason for removal
+            // when the general and specific are both present
+            // Otherwise leave the general reason
+            if (matchingCiReasons.contains(ciGeneralReasonToFilterOut)
+                    && matchingCiReasons.contains(ciSpecificReason)) {
+                reasonsToFilter.add(ciGeneralReasonToFilterOut);
+                logger.info(
+                        "General CI reason {} suppressed in favour of specific reason {}",
+                        ciGeneralReasonToFilterOut,
+                        ciSpecificReason);
+            }
+        }
+
+        // Now remove the filtered reasons
+        // reason removal not done inline to support 2+ specifics
+        // e.g. specific>specific>general mappings
+        matchingCiReasons.removeAll(reasonsToFilter);
+
+        // Checks Passed
+        List<String> presentNotMatchingCiChecks =
+                presentNotMatchingCiMappings.stream()
+                        .map(ContraIndicatorComplexMapping::getCheck)
+                        .collect(Collectors.toList());
+
+        // Check Failed
+        List<String> matchingCiChecks =
+                matchingCiMappings.stream()
+                        .map(ContraIndicatorComplexMapping::getCheck)
+                        .collect(Collectors.toList());
+
+        // Results of processing - lists never null
+        return ContraIndicatorMapperResult.builder()
+                .contraIndicators(deDuplicatedContraIndicators)
+                .contraIndicatorReasons(matchingCiReasons)
+                .contraIndicatorChecks(presentNotMatchingCiChecks)
+                .contraIndicatorFailedChecks(matchingCiChecks)
+                .build();
+    }
+
+    // Method around filter as the filter is used multiple times and needs to be the same
+    private boolean ciMapFilter(Map<String, String> flagMap, String flag) {
+
+        String filterValue = flagToContraIndicatorMappings.get(flag).requiredFlagValue;
+        String flagValue = flagMap.get(flag);
+
+        return filterValue.equals(flagValue);
     }
 }

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/DocumentDataVerificationService.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/DocumentDataVerificationService.java
@@ -192,6 +192,7 @@ public class DocumentDataVerificationService {
 
         ContraIndicatorMapperResult contraIndicatorMapperResult;
 
+        // should we not check failed first. Why do all this if were going to clear anyway
         // Legacy API will not set any flags
         if (thirdPartyAPIResult.getFlags() != null) {
             Map<String, String> flagMap = thirdPartyAPIResult.getFlags();

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/DocumentDataVerificationService.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/DocumentDataVerificationService.java
@@ -13,6 +13,7 @@ import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.passport.checkpassport.domain.result.DocumentDataVerificationResult;
 import uk.gov.di.ipv.cri.passport.checkpassport.domain.result.ThirdPartyAPIResult;
 import uk.gov.di.ipv.cri.passport.checkpassport.domain.result.fields.APIResultSource;
+import uk.gov.di.ipv.cri.passport.checkpassport.domain.result.fields.ContraIndicatorMapperResult;
 import uk.gov.di.ipv.cri.passport.checkpassport.validation.ValidationResult;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportFormData;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
@@ -20,14 +21,10 @@ import uk.gov.di.ipv.cri.passport.library.exceptions.OAuthErrorResponseException
 import uk.gov.di.ipv.cri.passport.library.helpers.PersonIdentityDetailedHelperMapper;
 import uk.gov.di.ipv.cri.passport.library.service.ServiceFactory;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
-import static uk.gov.di.ipv.cri.passport.library.domain.CheckType.DOCUMENT_DATA_VERIFICATION;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.DOCUMENT_DATA_VERIFICATION_REQUEST_FAILED;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.DOCUMENT_DATA_VERIFICATION_REQUEST_SUCCEEDED;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_VALIDATION_FAIL;
@@ -36,7 +33,9 @@ import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_V
 public class DocumentDataVerificationService {
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private static final String DOCUMENT_VALIDITY_CI = "D02";
+    private static final String DOCUMENT_DATA_VERIFICATION_CI = "D02";
+    private static final String DOCUMENT_DATA_VERIFICATION_CHECK_NAME = "record_check";
+    private static final String DOCUMENT_DATA_VERIFICATION_CI_REASON = "NoMatchingRecord";
 
     private static final int MAX_PASSPORT_GPG45_STRENGTH_VALUE = 4;
     private static final int MAX_PASSPORT_GPG45_VALIDITY_VALUE = 2;
@@ -104,8 +103,10 @@ public class DocumentDataVerificationService {
             APIResultSource apiResultSource = thirdPartyAPIResult.getApiResultSource();
 
             LOGGER.info("Mapping contra-indicators from Third party response");
-            List<String> cis = calculateContraIndicators(thirdPartyAPIResult);
+            ContraIndicatorMapperResult contraIndicatorMapperResult =
+                    getContraIndicatorsResult(thirdPartyAPIResult);
 
+            List<String> cis = contraIndicatorMapperResult.getContraIndicators();
             int documentStrengthScore = MAX_PASSPORT_GPG45_STRENGTH_VALUE;
             int documentValidityScore = calculateValidity(thirdPartyAPIResult, cis);
 
@@ -136,15 +137,13 @@ public class DocumentDataVerificationService {
             documentDataVerificationResult.setTransactionId(thirdPartyAPIResult.getTransactionId());
             documentDataVerificationResult.setVerified(thirdPartyAPIResult.isValid());
 
-            List<String> checksSucceeded = new ArrayList<>();
-            List<String> checksFailed = new ArrayList<>();
-            if (documentDataVerificationResult.isVerified() && cis.isEmpty()) {
-                checksSucceeded.add(DOCUMENT_DATA_VERIFICATION.toString());
-            } else {
-                checksFailed.add(DOCUMENT_DATA_VERIFICATION.toString());
-            }
-            documentDataVerificationResult.setChecksSucceeded(checksSucceeded);
-            documentDataVerificationResult.setChecksFailed(checksFailed);
+            // See ContraIndicatorMapperResult as CI Mapper handles CI, CIReasons and CIChecks
+            documentDataVerificationResult.setChecksSucceeded(
+                    contraIndicatorMapperResult.getContraIndicatorChecks());
+            documentDataVerificationResult.setChecksFailed(
+                    contraIndicatorMapperResult.getContraIndicatorFailedChecks());
+            documentDataVerificationResult.setContraIndicatorReasons(
+                    contraIndicatorMapperResult.getContraIndicatorReasons());
 
             LOGGER.info("Sending audit event {}...", AuditEventType.RESPONSE_RECEIVED);
             auditService.sendAuditEvent(
@@ -187,14 +186,11 @@ public class DocumentDataVerificationService {
                 : MAX_PASSPORT_GPG45_VALIDITY_VALUE;
     }
 
-    private List<String> calculateContraIndicators(ThirdPartyAPIResult thirdPartyAPIResult) {
+    // Handles the special case processing for the DOCUMENT_DATA_VERIFICATION_CI
+    private ContraIndicatorMapperResult getContraIndicatorsResult(
+            ThirdPartyAPIResult thirdPartyAPIResult) {
 
-        // Set used to prevent duplicate CI's
-        final Set<String> contraIndicators = new HashSet<>();
-
-        if (!thirdPartyAPIResult.isValid()) {
-            contraIndicators.add(DOCUMENT_VALIDITY_CI);
-        }
+        ContraIndicatorMapperResult contraIndicatorMapperResult;
 
         // Legacy API will not set any flags
         if (thirdPartyAPIResult.getFlags() != null) {
@@ -207,16 +203,46 @@ public class DocumentDataVerificationService {
                 LOGGER.debug(message);
             }
 
-            List<String> flagCIs = contraIndicatorMapper.mapFlagsToCIs(flagMap);
+            contraIndicatorMapperResult = contraIndicatorMapper.mapFlagsToCIs(flagMap);
 
+            List<String> flagCIs = contraIndicatorMapperResult.getContraIndicators();
             for (String ci : flagCIs) {
-                String message = String.format("CI %s ", ci);
+                String message = String.format("Flag CI's %s ", ci);
                 LOGGER.debug(message);
             }
 
-            contraIndicators.addAll(flagCIs);
+        } else {
+            // To maintain legacy compatibility incase DCS needs was re-enabled
+            contraIndicatorMapperResult = ContraIndicatorMapperResult.builder().build();
         }
 
-        return new ArrayList<>(Set.copyOf(contraIndicators));
+        List<String> ciCodes = contraIndicatorMapperResult.getContraIndicators();
+        List<String> ciReason = contraIndicatorMapperResult.getContraIndicatorReasons();
+
+        List<String> ciChecks = contraIndicatorMapperResult.getContraIndicatorChecks();
+        List<String> ciFailedChecks = contraIndicatorMapperResult.getContraIndicatorFailedChecks();
+
+        // isValid to VERIFICATION mapping is not processed as a flag
+        if (!thirdPartyAPIResult.isValid()) {
+
+            // Ensure in this scenario that all other flags are ignored
+            ciCodes.clear();
+            ciReason.clear();
+            ciChecks.clear();
+            ciFailedChecks.clear();
+
+            // CI's
+            ciCodes.add(DOCUMENT_DATA_VERIFICATION_CI);
+
+            // Verification CI Reason "CI,Reason"
+            ciReason.add(
+                    DOCUMENT_DATA_VERIFICATION_CI + "," + DOCUMENT_DATA_VERIFICATION_CI_REASON);
+
+            ciFailedChecks.add(DOCUMENT_DATA_VERIFICATION_CHECK_NAME);
+        } else {
+            ciChecks.add(DOCUMENT_DATA_VERIFICATION_CHECK_NAME);
+        }
+
+        return contraIndicatorMapperResult;
     }
 }

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
@@ -668,7 +668,7 @@ class CheckPassportHandlerTest {
                 documentDataVerificationResult.getChecksSucceeded());
         documentCheckResultItem.setFailedCheckDetails(
                 documentDataVerificationResult.getChecksFailed());
-
+        documentCheckResultItem.setCiReasons(new ArrayList<>());
         return documentCheckResultItem;
     }
 }

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
@@ -72,8 +72,14 @@ import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.IS_DCS_PERFORMANCE_STUB;
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.IS_DVAD_PERFORMANCE_STUB;
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.MAXIMUM_ATTEMPT_COUNT;
-import static uk.gov.di.ipv.cri.passport.library.domain.CheckType.DOCUMENT_DATA_VERIFICATION;
-import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.*;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_FAIL;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_PASS;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_RETRY;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_UNVERIFIED;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_COMPLETED_OK;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_USER_REDIRECTED_ATTEMPTS_OVER_MAX;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SystemStubsExtension.class)
@@ -139,8 +145,7 @@ class CheckPassportHandlerTest {
         DocumentDataVerificationResult testDocumentDataVerificationResult =
                 DocumentDataVerificationServiceResultDataGenerator.generate(passportFormData);
         testDocumentDataVerificationResult.setContraIndicators(new ArrayList<>());
-        testDocumentDataVerificationResult.setChecksSucceeded(
-                List.of(DOCUMENT_DATA_VERIFICATION.toString()));
+        testDocumentDataVerificationResult.setChecksSucceeded(List.of("verification_check"));
 
         APIGatewayProxyRequestEvent mockRequestEvent =
                 Mockito.mock(APIGatewayProxyRequestEvent.class);
@@ -229,12 +234,10 @@ class CheckPassportHandlerTest {
         DocumentDataVerificationResult testDocumentDataVerificationResult =
                 DocumentDataVerificationServiceResultDataGenerator.generate(passportFormData);
         if (documentVerified) {
-            testDocumentDataVerificationResult.setChecksSucceeded(
-                    List.of(DOCUMENT_DATA_VERIFICATION.toString()));
+            testDocumentDataVerificationResult.setChecksSucceeded(List.of("verification_check"));
             testDocumentDataVerificationResult.setContraIndicators(new ArrayList<>());
         } else {
-            testDocumentDataVerificationResult.setChecksFailed(
-                    List.of(DOCUMENT_DATA_VERIFICATION.toString()));
+            testDocumentDataVerificationResult.setChecksFailed(List.of("verification_check"));
         }
 
         testDocumentDataVerificationResult.setVerified(documentVerified); // Test Parameter
@@ -487,7 +490,6 @@ class CheckPassportHandlerTest {
         CommonExpressOAuthError expectedObject =
                 new CommonExpressOAuthError(
                         OAuth2Error.SERVER_ERROR, OAuth2Error.SERVER_ERROR.getDescription());
-        System.out.println(responseTreeRootNode);
 
         assertNotNull(responseEvent);
         assertNotNull(responseTreeRootNode);

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ContraIndicatorComplexMappingTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ContraIndicatorComplexMappingTest.java
@@ -1,0 +1,82 @@
+package uk.gov.di.ipv.cri.passport.checkpassport.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class ContraIndicatorComplexMappingTest {
+
+    @Test
+    void shouldCreateContraIndicatorComplexMappingFromSingleCamelFlag() {
+
+        ContraIndicatorComplexMapping ciCM =
+                new ContraIndicatorComplexMapping("A01", "flagOne", "1234");
+
+        assertEquals("One", ciCM.getReason());
+        assertEquals("one_check", ciCM.getCheck());
+        assertEquals("A01", ciCM.getCi());
+        assertEquals("1234", ciCM.getRequiredFlagValue());
+    }
+
+    @Test
+    void shouldCreateContraIndicatorComplexMappingFromDoubleCamelFlag() {
+        ContraIndicatorComplexMapping ciCM =
+                new ContraIndicatorComplexMapping("B01", "doubleFlagOne", "ABC");
+
+        assertEquals("FlagOne", ciCM.getReason());
+        assertEquals("flag_one_check", ciCM.getCheck());
+        assertEquals("B01", ciCM.getCi());
+        assertEquals("ABC", ciCM.getRequiredFlagValue());
+    }
+
+    @Test
+    void shouldCreateContraIndicatorComplexMappingFromTripleCamelFlag() {
+        ContraIndicatorComplexMapping ciCM =
+                new ContraIndicatorComplexMapping("C01", "tripleFlagAbCd", "123ABC++");
+
+        assertEquals("FlagAbCd", ciCM.getReason());
+        assertEquals("flag_ab_cd_check", ciCM.getCheck());
+        assertEquals("C01", ciCM.getCi());
+        assertEquals("123ABC++", ciCM.getRequiredFlagValue());
+    }
+
+    @Test
+    void shouldThrowExceptionIfFlagIsAllLowerCase() {
+
+        IllegalStateException thrownException =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> new ContraIndicatorComplexMapping("L01", "abc", "false"));
+
+        assertEquals(
+                "Flag abc not in the expected camel case format", thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionIfFlagIsAllNumeric() {
+
+        IllegalStateException thrownException =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> new ContraIndicatorComplexMapping("N01", "1234", "false"));
+
+        assertEquals(
+                "Flag 1234 not in the expected camel case format", thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionIfFlagIsTitleCase() {
+
+        IllegalStateException thrownException =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> new ContraIndicatorComplexMapping("T01", "FlagOne", "false"));
+
+        assertEquals(
+                "Flag FlagOne not in the expected camel case format", thrownException.getMessage());
+    }
+}

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ContraindicationMappingsTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ContraindicationMappingsTest.java
@@ -55,25 +55,13 @@ class ContraindicationMappingsTest {
     private static final String MAPPING_CI_FLAG_3 =
             String.format(SINGLE_MAPPING_FORMAT, "flagThree", true, "C03");
     private static final String MAPPING_CI_FLAG_4 =
-            String.format(MULTI_MAPPING_FORMAT, "flagFour", true, "flagFive", false, "D04");
+            String.format(MULTI_MAPPING_FORMAT, "flagFive", false, "flagFour", true, "D04");
     private static final String MAPPING_CI_FLAG_5 =
-            String.format(
-                    MULTI_MAPPING_FORMAT_CI_REASON_OVERRIDE,
-                    "flagSix",
-                    true,
-                    "flagSeven",
-                    true,
-                    "E05");
+            String.format("%s@%s,%s@%s:%s", "flagSeven", true, "flagSix", true, "E05");
     private static final String MAPPING_CI_FLAG_6 =
             String.format(
-                    TRIPLE_MAPPING_FORMAT_CI_REASON_OVERRIDE,
-                    "flagEight",
-                    true,
-                    "flagNine",
-                    true,
-                    "flagTen",
-                    true,
-                    "F06");
+                    "%s@%s,%s@%s,%s@%s:%s",
+                    "flagTen", true, "flagEight", true, "flagNine", true, "F06");
 
     // CI Map containing all the mappings above
     private static final String CI_MAP =
@@ -204,7 +192,8 @@ class ContraindicationMappingsTest {
         assertTrue(ciFailedChecks.contains("two_check"));
     }
 
-    @Test
+    // Current implementation does not allow for multi reasons to one CI
+    /*    @Test
     void shouldReturnSingleCIForFlagsInMultiMapping() {
         Map<String, String> testflagMap = new HashMap<>();
         testflagMap.put("flagFour", "true");
@@ -238,7 +227,7 @@ class ContraindicationMappingsTest {
         assertEquals(2, ciFailedChecks.size());
         assertTrue(ciFailedChecks.contains("four_check"));
         assertTrue(ciFailedChecks.contains("five_check"));
-    }
+    }*/
 
     @Test
     void shouldReturnNoCIIfFlagValuesDoNotMatchMapping() {

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/services/dvad/DvadThirdPartyAPIServiceTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/services/dvad/DvadThirdPartyAPIServiceTest.java
@@ -489,8 +489,8 @@ class DvadThirdPartyAPIServiceTest {
         }
 
         // For anyone extending or updating this
-        System.out.println("messagePartMap");
-        System.out.println(messagePartMap.toString());
+        //  print out ("messagePartMap");
+        // print out (messagePartMap.toString());
 
         // Check the messageParts contents for each scenario
         switch (scenario) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/CiReasons.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/CiReasons.java
@@ -1,0 +1,25 @@
+package uk.gov.di.ipv.cri.passport.issuecredential.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CiReasons {
+
+    @JsonProperty("ci")
+    private final String ci;
+
+    @JsonProperty("reason")
+    private final String reason;
+
+    public CiReasons(String ci, String reason) {
+        this.ci = ci;
+        this.reason = reason;
+    }
+
+    public String getCi() {
+        return ci;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/checkdetails/Check.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/checkdetails/Check.java
@@ -11,8 +11,8 @@ import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverage
 @JsonPropertyOrder({"txn", "checkMethod", "passportCheck"})
 public class Check {
 
-    @JsonIgnore // @JsonProperty("passportCheck")
-    private String passportCheck;
+    @JsonProperty("dataCheck")
+    private String dataCheck;
 
     @JsonProperty("checkMethod")
     private String checkMethod = "data";
@@ -20,12 +20,12 @@ public class Check {
     @JsonIgnore // @JsonProperty("txn")
     private String txn;
 
-    public Check(String passportCheck) {
-        this.passportCheck = passportCheck;
+    public Check(String dataCheck) {
+        this.dataCheck = dataCheck;
     }
 
-    public String getPassportCheck() {
-        return passportCheck;
+    public String getDataCheck() {
+        return dataCheck;
     }
 
     public String getCheckMethod() {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/checkdetails/Check.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/checkdetails/Check.java
@@ -8,7 +8,7 @@ import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverage
 
 @ExcludeFromGeneratedCoverageReport
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"txn", "checkMethod", "passportCheck"})
+@JsonPropertyOrder({"txn", "checkMethod", "dataCheck"})
 public class Check {
 
     @JsonProperty("dataCheck")

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/verifiablecredential/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/verifiablecredential/Evidence.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.passport.issuecredential.domain.verifiablecredential;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.issuecredential.domain.CiReasons;
 import uk.gov.di.ipv.cri.passport.issuecredential.domain.checkdetails.Check;
 
 import java.util.List;
@@ -19,6 +20,8 @@ public class Evidence {
     private List<Check> checkDetails;
 
     private List<Check> failedCheckDetails;
+
+    private List<CiReasons> ciReasons;
 
     public Evidence() {}
 
@@ -83,6 +86,14 @@ public class Evidence {
 
     public void setFailedCheckDetails(List<Check> failedCheckDetails) {
         this.failedCheckDetails = failedCheckDetails;
+    }
+
+    public List<CiReasons> getCiReasons() {
+        return ciReasons;
+    }
+
+    public void setCiReasons(List<CiReasons> ciReasons) {
+        this.ciReasons = ciReasons;
     }
 
     @Override

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/verifiablecredential/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/verifiablecredential/Evidence.java
@@ -99,16 +99,24 @@ public class Evidence {
     @Override
     public String toString() {
         return "Evidence{"
-                + "type="
+                + "type='"
                 + type
-                + ", txn="
+                + '\''
+                + ", txn='"
                 + txn
-                + ", strength="
+                + '\''
+                + ", strengthScore="
                 + strengthScore
-                + ", validity="
+                + ", validityScore="
                 + validityScore
                 + ", ci="
                 + ci
+                + ", checkDetails="
+                + checkDetails
+                + ", failedCheckDetails="
+                + failedCheckDetails
+                + ", ciReasons="
+                + ciReasons
                 + '}';
     }
 }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/util/EvidenceHelper.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/util/EvidenceHelper.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.cri.passport.issuecredential.util;
 
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.issuecredential.domain.CiReasons;
 import uk.gov.di.ipv.cri.passport.issuecredential.domain.checkdetails.Check;
 import uk.gov.di.ipv.cri.passport.issuecredential.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.passport.issuecredential.domain.verifiablecredential.EvidenceType;
@@ -34,6 +35,19 @@ public class EvidenceHelper {
         List<String> stringFailedCheckDetails = documentCheckResultItem.getFailedCheckDetails();
         if (stringFailedCheckDetails != null && !stringFailedCheckDetails.isEmpty()) {
             evidence.setFailedCheckDetails(createCheckList(stringFailedCheckDetails));
+        }
+
+        List<String> ciReasonPairs = documentCheckResultItem.getCiReasons();
+        List<CiReasons> ciReasons = new ArrayList<>();
+
+        if (ciReasonPairs != null) {
+            for (String pair : ciReasonPairs) {
+
+                String[] ciReasonPair = pair.split(",");
+
+                ciReasons.add(new CiReasons(ciReasonPair[0], ciReasonPair[1]));
+            }
+            evidence.setCiReasons(ciReasons);
         }
 
         return evidence;

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
@@ -194,14 +194,17 @@ class VerifiableCredentialServiceTest implements VerifiableCredentialServiceTest
         if (verified) {
             // Verified VC has no CI
             assertNull(evidence.get("ci"));
-            assertEquals("[{\"checkMethod\":\"data\"}]", evidence.get("checkDetails").toString());
+            assertEquals(
+                    "[{\"checkMethod\":\"data\",\"dataCheck\":\"verification_check\"}]",
+                    evidence.get("checkDetails").toString());
 
         } else {
             assertEquals(
                     documentCheckResultItem.getContraIndicators().get(0),
                     evidence.get("ci").get(0).asText());
             assertEquals(
-                    "[{\"checkMethod\":\"data\"}]", evidence.get("failedCheckDetails").toString());
+                    "[{\"checkMethod\":\"data\",\"dataCheck\":\"verification_check\"}]",
+                    evidence.get("failedCheckDetails").toString());
         }
 
         ECDSAVerifier ecVerifier =

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/CheckType.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/CheckType.java
@@ -1,8 +1,0 @@
-package uk.gov.di.ipv.cri.passport.library.domain;
-
-import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
-
-@ExcludeFromGeneratedCoverageReport
-public enum CheckType {
-    DOCUMENT_DATA_VERIFICATION, // Placeholder name
-}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/DocumentCheckResultItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/DocumentCheckResultItem.java
@@ -22,6 +22,7 @@ public class DocumentCheckResultItem {
 
     private List<String> checkDetails;
     private List<String> failedCheckDetails;
+    private List<String> ciReasons;
 
     private long ttl;
 
@@ -96,6 +97,14 @@ public class DocumentCheckResultItem {
 
     public void setFailedCheckDetails(List<String> failedCheckDetails) {
         this.failedCheckDetails = failedCheckDetails;
+    }
+
+    public void setCiReasons(List<String> ciReasons) {
+        this.ciReasons = ciReasons;
+    }
+
+    public List<String> getCiReasons() {
+        return ciReasons;
     }
 
     public long getTtl() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/DocumentCheckResultItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/DocumentCheckResultItem.java
@@ -128,7 +128,8 @@ public class DocumentCheckResultItem {
                 && Objects.equals(documentNumber, that.documentNumber)
                 && Objects.equals(expiryDate, that.expiryDate)
                 && Objects.equals(checkDetails, that.checkDetails)
-                && Objects.equals(failedCheckDetails, that.failedCheckDetails);
+                && Objects.equals(failedCheckDetails, that.failedCheckDetails)
+                && Objects.equals(ciReasons, that.ciReasons);
     }
 
     @Override
@@ -143,6 +144,7 @@ public class DocumentCheckResultItem {
                 expiryDate,
                 checkDetails,
                 failedCheckDetails,
-                ttl);
+                ttl,
+                ciReasons);
     }
 }

--- a/lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/DocumentCheckTestDataGenerator.java
+++ b/lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/DocumentCheckTestDataGenerator.java
@@ -6,8 +6,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
-import static uk.gov.di.ipv.cri.passport.library.domain.CheckType.DOCUMENT_DATA_VERIFICATION;
-
 public class DocumentCheckTestDataGenerator {
 
     private DocumentCheckTestDataGenerator() {
@@ -42,7 +40,9 @@ public class DocumentCheckTestDataGenerator {
 
         documentCheckResultItem.setTransactionId(UUID.randomUUID().toString());
 
-        documentCheckResultItem.setCheckDetails(List.of(DOCUMENT_DATA_VERIFICATION.toString()));
+        documentCheckResultItem.setCheckDetails(List.of("verification_check"));
+
+        documentCheckResultItem.setCiReasons(null);
 
         return documentCheckResultItem;
     }
@@ -65,8 +65,9 @@ public class DocumentCheckTestDataGenerator {
 
         documentCheckResultItem.setTransactionId(UUID.randomUUID().toString());
 
-        documentCheckResultItem.setFailedCheckDetails(
-                List.of(DOCUMENT_DATA_VERIFICATION.toString()));
+        documentCheckResultItem.setFailedCheckDetails(List.of("verification_check"));
+
+        documentCheckResultItem.setCiReasons(List.of("CI1,Verification"));
 
         return documentCheckResultItem;
     }


### PR DESCRIPTION
## Proposed changes

### What changed

Reworked ContraIndicatorMapper to handle the processing of CI's, CI Reasons, Checks and failed checks for response flags. As part of the CI Mapping format changed.

Removed document-check route header from pre-merge tests (not longer used)
Pre-merge tests updated and aligned with flag obfuscation.

Update readme for aws vault usage

### Why did it change

ContraIndicatorMapper reworked as this was the best place to handle the mapping, but needed support added to handle conditional appearance of CI reasons, with out reference to any response flags by name in code.

Document-check route header removal from tests -DVA-Direct only route used, with DCS is currently being decommissioned.

Pre-merge tests previously assert evidence content by String, this is now done via expected hashes based on numbered scenarios - to avoid the tests needing to know exact flag values/names.

Authentication via aws vault is now the only supported authentication method.

### Issue tracking

- [LIME-832](https://govukverify.atlassian.net/browse/LIME-832)
- [LIME-833](https://govukverify.atlassian.net/browse/LIME-833)



[LIME-832]: https://govukverify.atlassian.net/browse/LIME-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ