### PR TITLE
LIME-498 - Removing subscriptionFilter to unblock pipeline

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -677,14 +677,6 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${CertExpiryReminderFunction}"
       RetentionInDays: 30
 
-  CertExpiryReminderFunctionLogGroupSubscriptionFilter:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: LogSendingEnabled
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-      FilterPattern: ""
-      LogGroupName: !Ref CertExpiryReminderFunctionLogGroup
-
   CertExpiryReminderFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:


### PR DESCRIPTION
### What changed

Removed subscription filter as aws account doesn't have permissions to make a new one, logs for this lambda are not needed in splunk so removing for now to unblock pipelines