### PR TITLE
LIME-727 Increase Passport API Throttle/Throttling limits

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -170,6 +170,23 @@ Mappings:
       integration: 2
       production: 2
 
+  MemorySizeMapping:
+    Environment:
+      dev: 2048
+      build: 4096
+      staging: 2048
+      integration: 2048
+      production: 4096
+
+  # VC Only
+  MaxJwtTtlMapping:
+    Environment:
+      dev: "2"
+      build: "2"
+      staging: "6"
+      integration: "6"
+      production: "6"
+
   DvaDigitalEnabledMapping:
     Environment:
       dev: "true"
@@ -186,14 +203,6 @@ Mappings:
       integration: 1
       production: 1
 
-  MemorySizeMapping:
-    Environment:
-      dev: 2048
-      build: 3072
-      staging: 3072
-      integration: 3072
-      production: 3072
-
   VcExpiryRemoved:
     Environment:
       dev: "true"
@@ -202,14 +211,7 @@ Mappings:
       integration: "true"
       production: "true"
 
-  # VC Only
-  MaxJwtTtlMapping:
-    Environment:
-      dev: "2"
-      build: "2"
-      staging: "6"
-      integration: "6"
-      production: "6"
+
 
   # VC Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
   JwtTtlUnitMapping:
@@ -254,8 +256,8 @@ Resources:
           # Disable data trace in production to avoid logging customer sensitive information
           DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
-          ThrottlingRateLimit: 5
-          ThrottlingBurstLimit: 10
+          ThrottlingRateLimit: 200
+          ThrottlingBurstLimit: 400
       AccessLogSetting:
         DestinationArn: !GetAtt PublicUKPassportAPILogGroup.Arn
         Format: >-
@@ -351,8 +353,8 @@ Resources:
           # Disable data trace in production to avoid logging customer sensitive information
           DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
-          ThrottlingRateLimit: 5
-          ThrottlingBurstLimit: 10
+          ThrottlingRateLimit: 200
+          ThrottlingBurstLimit: 400
       AccessLogSetting:
         DestinationArn: !GetAtt PrivateUKPassportAPILogGroup.Arn
         Format: >-
@@ -740,8 +742,8 @@ Resources:
         Limit: 500000
         Period: DAY
       Throttle:
-        BurstLimit: 100 # requests the API can handle concurrently
-        RateLimit: 50 # allowed requests per second
+        RateLimit: 200 # allowed requests per second
+        BurstLimit: 400 # requests the API can handle concurrently
 
   PrivateUKPassportAPIUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
@@ -756,8 +758,8 @@ Resources:
         Limit: 500000
         Period: DAY
       Throttle:
-        BurstLimit: 100 # requests the API can handle concurrently
-        RateLimit: 50 # allowed requests per second
+        RateLimit: 200 # allowed requests per second
+        BurstLimit: 400 # requests the API can handle concurrently
 
   LinkUsagePlanApiKey1:
     Condition: IsDeployedFromPipeline


### PR DESCRIPTION
## Proposed changes

### What changed

Increase api rate/burst limits and lambda cpu allocation.

Moved some value maps.

### Why did it change

Align Passport API with DLAPI values

Value maps moved to allow 3-way diff between templates to line up.

### Issue tracking

- [LIME-727](https://govukverify.atlassian.net/browse/LIME-727)

[LIME-727]: https://govukverify.atlassian.net/browse/LIME-727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ