### PR TITLE
LIME-844 Fix deploy to dev action failure

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 7.6
+          gradle-version: wrapper
 
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v1


### PR DESCRIPTION
## Proposed changes

### What changed

Fix deploy to dev action failure.

### Why did it change

deploy to dev was hardcoded to gradle 7.6 - switched to wrapper version

### Issue tracking

- [LIME-844](https://govukverify.atlassian.net/browse/LIME-844)


[LIME-844]: https://govukverify.atlassian.net/browse/LIME-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ