### PR TITLE
LIME-991-smoke - Fix smoke tests via using the wrapper vs gradle directly

### DIFF
--- a/.github/workflows/dailyPassportSmokeTest.yml
+++ b/.github/workflows/dailyPassportSmokeTest.yml
@@ -26,6 +26,8 @@ jobs:
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
       - uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: wrapper
 
       - name: Run Passport Smoke test against staging environment
         env:
@@ -36,7 +38,7 @@ jobs:
           coreStubUsername: ${{ secrets.PASSPORT_CORE_STUB_USERNAME }}
           coreStubPassword: ${{ secrets.PASSPORT_CORE_STUB_PASSWORD }}
           orchestratorStubUrl: ${{ secrets.ORCHESTRATOR_STUB_URL }}
-        run: cd acceptance-tests && gradle passportCriSmokeStaging
+        run: cd acceptance-tests && ./gradlew passportCriSmokeStaging
 
       - name: Get test results history
         uses: actions/checkout@v4

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -57,10 +57,12 @@ dependencies {
 		// testFixturesImplementation
 
 		// acceptance tests Implementation
-		cucumber_version                   : "7.13.0",
-		selenium_version                   : "4.11.0",
+		// Update these together
+		cucumber_version                   : "7.15.0",
+		selenium_version                   : "4.18.1",
 		axe_core_selenium_version          : "4.6.0",
-		webdrivermanager_version           : "5.6.3",
+		webdrivermanager_version           : "5.6.4",
+
 		// acceptance tests testImplementation
 		rest_assured_version               : "5.3.0",
 		cucumber_junit_version             : "7.13.0"

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/UniversalSteps.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/UniversalSteps.java
@@ -5,22 +5,21 @@ import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.support.PageFactory;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.Driver;
 
-import java.time.Duration;
-
 import static org.junit.Assert.assertTrue;
+import static uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils.waitForPageToLoad;
 
 public class UniversalSteps {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private static final int WAIT_DELAY_SEC = 10;
+    private static final int MAX_WAIT_SEC = 10;
 
     public UniversalSteps() {
         PageFactory.initElements(Driver.get(), this);
     }
 
     public void assertPageTitle(String expTitle, boolean fuzzy) {
-        ImplicitlyWait();
+        waitForPageToLoad(MAX_WAIT_SEC);
 
         String title = Driver.get().getTitle();
 
@@ -35,15 +34,11 @@ public class UniversalSteps {
     }
 
     public void assertURLContains(String expected) {
-        ImplicitlyWait();
+        waitForPageToLoad(MAX_WAIT_SEC);
 
         String url = Driver.get().getCurrentUrl();
 
         LOGGER.info("Page url: " + url);
         assertTrue(url.contains(expected));
-    }
-
-    public static void ImplicitlyWait() {
-        Driver.get().manage().timeouts().implicitlyWait(Duration.ofSeconds(WAIT_DELAY_SEC));
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
@@ -122,7 +122,7 @@ public class PassportStepDefs extends PassportPageObject {
     }
 
     @And("^I see the passport Selection sentence starts with (.*)$")
-    public void ICanSeeThePageDescriptionAs(String expectedText) throws Throwable {
+    public void ICanSeeThePageDescriptionAs(String expectedText) {
         assertPageDescription(expectedText);
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/Driver.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/Driver.java
@@ -38,13 +38,14 @@ public class Driver {
                     break;
                 case "chrome-headless":
                     WebDriverManager.chromedriver().setup();
-                    ChromeOptions chromeOptions = new ChromeOptions().setHeadless(true);
+                    ChromeOptions chromeOptions = new ChromeOptions();
                     chromeOptions.addArguments("--remote-allow-origins=*");
+                    chromeOptions.addArguments("--headless");
+
                     if (ConfigurationReader.noChromeSandbox()) {
                         // no-sandbox is needed for chrome-headless when running in a container due
                         // to restricted syscalls
                         chromeOptions.addArguments("--no-sandbox");
-                        chromeOptions.addArguments("--headless");
                         chromeOptions.addArguments("--whitelisted-ips= ");
                         chromeOptions.addArguments("--disable-dev-shm-usage");
                         chromeOptions.addArguments("--remote-debugging-port=9222");
@@ -61,7 +62,11 @@ public class Driver {
                     break;
                 case "firefox-headless":
                     WebDriverManager.firefoxdriver().setup();
-                    driverPool.set(new FirefoxDriver(new FirefoxOptions().setHeadless(true)));
+
+                    FirefoxOptions firefoxOptions = new FirefoxOptions();
+                    firefoxOptions.addArguments("--headless");
+
+                    driverPool.set(new FirefoxDriver(firefoxOptions));
                     break;
                 case "ie":
                     if (!System.getProperty("os.name").toLowerCase().contains("windows"))


### PR DESCRIPTION
## Proposed changes

### What changed

Fix smoke tests via using the wrapper vs gradle directly

	- Added note to update the following cucumber_version, selenium_version and webdrivermanager_version together
	- Updated cucumber_version, selenium_version and webdrivermanager_version
	- Fixed race condition for page title assertions via waitForPageToLoad
	- Fix setHeadless removal
	- Added "with gradle-version: wrapper" to setup gradle action

- [LIME-991](https://govukverify.atlassian.net/browse/LIME-991)


[LIME-991]: https://govukverify.atlassian.net/browse/LIME-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ