### PR TITLE
LIME-1049 Fix the tests that are failing in Passport CRI

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
@@ -42,6 +42,8 @@ public class PassportPageObject extends UniversalSteps {
 
     private static final String STUB_VC_PAGE_TITLE = "IPV Core Stub Credential Result - GOV.UK";
 
+    private static final String STUB_ERROR_PAGE_TITLE = "IPV Core Stub - GOV.UK";
+
     // Should be separate stub page
 
     @FindBy(xpath = "//*[@id=\"main-content\"]/p/a/button")
@@ -127,7 +129,7 @@ public class PassportPageObject extends UniversalSteps {
     @FindBy(xpath = "/html/head/link[1]")
     public WebElement cookiePreference;
 
-    @FindBy(id = "error-summary-title")
+    @FindBy(className = "govuk-error-summary__title")
     public WebElement errorSummaryTitle;
 
     @FindBy(id = "passportNumber")
@@ -310,13 +312,15 @@ public class PassportPageObject extends UniversalSteps {
     }
 
     public void navigateToPassportResponse(String validOrInvalid) {
-        assertPageTitle(STUB_VC_PAGE_TITLE, false);
-        assertURLContains("callback");
         if ("Invalid".equalsIgnoreCase(validOrInvalid)) {
-            BrowserUtils.waitForVisibility(errorResponse, 5);
+            assertPageTitle(STUB_ERROR_PAGE_TITLE, false);
+            assertURLContains("callback");
+            BrowserUtils.waitForVisibility(errorResponse, 10);
             errorResponse.click();
         } else {
-            BrowserUtils.waitForVisibility(viewResponse, 5);
+            assertPageTitle(STUB_VC_PAGE_TITLE, false);
+            assertURLContains("callback");
+            BrowserUtils.waitForVisibility(viewResponse, 10);
             viewResponse.click();
         }
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/UniversalSteps.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/UniversalSteps.java
@@ -12,7 +12,7 @@ public class UniversalSteps {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private static final int MAX_WAIT_SEC = 10;
+    private static final int MAX_WAIT_SEC = 60;
 
     public UniversalSteps() {
         PageFactory.initElements(Driver.get(), this);

--- a/acceptance-tests/src/test/resources/features/passport/English/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/English/Passport.feature
@@ -153,7 +153,6 @@ Feature: Passport Test
   @Passport_test @smoke
   Scenario: Passport User cancels before first attempt via prove your identity another way route
     Given User click on ‘prove your identity another way' Link
-    Then User selects prove another way radio button
     Then I navigate to the passport verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
The following tests have been fixed
1) Scenario name : Passport User cancels before first attempt via prove your identity another way route
Test step 'User selects prove another way radio button' has been removed from the test and navigateToPassportResponse() method has been updated.

2) Scenario name : Passport details IncorrectDateOfBirth error message in Welsh
Scenario name : Passport Valid until date field error message in Welsh
The web element on the method for test step 'the validation text reads Mae problem' has been updated on both the tests.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
