### PR TITLE
LIME-983 - Updating configuration to handle routing to 3rd party base…

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,21 @@ To run API tests locally you need
 Acceptance tests
 - build/staging test can be run against the environments.
 - Using a locally running stub and front, with a manually deployed api stack configured to match the environments.
+
+## TestData Strategy
+
+For testing purposes, this CRI has the ability to route users requests to either
+a real 3rd Party UAT instance of the service OR route users requests to an internally
+managed, stubbed version of the 3rd party service.
+
+Routing for the above is dictated by the client ID sent to the CRI from IPVCore/stubs. For lower
+environments there is an IPV core stub that is configured to for routing CRIs to 3rd party stubs and another
+IPV core stub that is configured for routing CRIs to the 3rd party UAT environment.
+
+For testing purposes if you wish to route to the stubbed version of the 3rd party then use the following
+core stub URL - https://cri.core.stubs.account.gov.uk/
+If you wish to route to the real 3rd partys UAT instance of the service use the following
+core stub url - https://cri-3rdparty.core.stubs.account.gov.uk/
+
+Additional details on these stubs can be found on this confluence page -
+https://govukverify.atlassian.net/wiki/spaces/OJ/pages/3147333723/Stubs+for+testing+journeys

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/DocumentDataVerificationService.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/DocumentDataVerificationService.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.cri.passport.checkpassport.domain.result.DocumentDataVerifi
 import uk.gov.di.ipv.cri.passport.checkpassport.domain.result.fields.ContraIndicatorMapperResult;
 import uk.gov.di.ipv.cri.passport.checkpassport.validation.ValidationResult;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportFormData;
+import uk.gov.di.ipv.cri.passport.library.domain.Strategy;
 import uk.gov.di.ipv.cri.passport.library.domain.result.ThirdPartyAPIResult;
 import uk.gov.di.ipv.cri.passport.library.domain.result.fields.APIResultSource;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
@@ -65,7 +66,8 @@ public class DocumentDataVerificationService {
             ThirdPartyAPIService thirdPartyAPIService,
             PassportFormData passportFormData,
             SessionItem sessionItem,
-            Map<String, String> requestHeaders)
+            Map<String, String> requestHeaders,
+            Strategy strategy)
             throws OAuthErrorResponseException {
         try {
             LOGGER.info("Validating form data...");
@@ -88,7 +90,7 @@ public class DocumentDataVerificationService {
             LOGGER.info(
                     "Performing data verification using {}", thirdPartyAPIService.getServiceName());
             ThirdPartyAPIResult thirdPartyAPIResult =
-                    thirdPartyAPIService.performCheck(passportFormData);
+                    thirdPartyAPIService.performCheck(passportFormData, strategy);
 
             LOGGER.info("Sending audit event {}...", AuditEventType.REQUEST_SENT);
             auditService.sendAuditEvent(

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/services/DocumentDataVerificationServiceTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/services/DocumentDataVerificationServiceTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.ipv.cri.passport.checkpassport.domain.result.fields.ContraIndic
 import uk.gov.di.ipv.cri.passport.checkpassport.validation.ValidationResult;
 import uk.gov.di.ipv.cri.passport.library.PassportFormTestDataGenerator;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportFormData;
+import uk.gov.di.ipv.cri.passport.library.domain.Strategy;
 import uk.gov.di.ipv.cri.passport.library.domain.result.ThirdPartyAPIResult;
 import uk.gov.di.ipv.cri.passport.library.domain.result.fields.APIResultSource;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
@@ -114,12 +115,16 @@ class DocumentDataVerificationServiceTest {
         when(mockFormDataValidator.validate(passportFormData))
                 .thenReturn(new ValidationResult<>(true, null));
 
-        when(mocThirdPartyAPIService.performCheck(passportFormData))
+        when(mocThirdPartyAPIService.performCheck(passportFormData, Strategy.NO_CHANGE))
                 .thenReturn(thirdPartyAPIResult);
 
         DocumentDataVerificationResult documentDataVerificationResult =
                 documentDataVerificationService.verifyData(
-                        mocThirdPartyAPIService, passportFormData, sessionItem, null);
+                        mocThirdPartyAPIService,
+                        passportFormData,
+                        sessionItem,
+                        null,
+                        Strategy.NO_CHANGE);
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(FORM_DATA_VALIDATION_PASS);
@@ -127,7 +132,7 @@ class DocumentDataVerificationServiceTest {
         verifyNoMoreInteractions(mockEventProbe);
 
         verify(mockFormDataValidator).validate(passportFormData);
-        verify(mocThirdPartyAPIService).performCheck(passportFormData);
+        verify(mocThirdPartyAPIService).performCheck(passportFormData, Strategy.NO_CHANGE);
 
         verify(mockAuditService)
                 .sendAuditEvent(eq(AuditEventType.REQUEST_SENT), any(AuditEventContext.class));
@@ -199,7 +204,11 @@ class DocumentDataVerificationServiceTest {
                         OAuthErrorResponseException.class,
                         () -> {
                             documentDataVerificationService.verifyData(
-                                    mocThirdPartyAPIService, passportFormData, sessionItem, null);
+                                    mocThirdPartyAPIService,
+                                    passportFormData,
+                                    sessionItem,
+                                    null,
+                                    Strategy.NO_CHANGE);
                         });
 
         assertEquals(expectedReturnedException.getStatusCode(), thrownException.getStatusCode());
@@ -228,14 +237,18 @@ class DocumentDataVerificationServiceTest {
 
         doThrow(expectedReturnedException)
                 .when(mocThirdPartyAPIService)
-                .performCheck(passportFormData);
+                .performCheck(passportFormData, Strategy.NO_CHANGE);
 
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
                         () -> {
                             documentDataVerificationService.verifyData(
-                                    mocThirdPartyAPIService, passportFormData, sessionItem, null);
+                                    mocThirdPartyAPIService,
+                                    passportFormData,
+                                    sessionItem,
+                                    null,
+                                    Strategy.NO_CHANGE);
                         });
 
         assertEquals(expectedReturnedException.getStatusCode(), thrownException.getStatusCode());
@@ -277,7 +290,11 @@ class DocumentDataVerificationServiceTest {
                         OAuthErrorResponseException.class,
                         () -> {
                             documentDataVerificationService.verifyData(
-                                    mocThirdPartyAPIService, passportFormData, sessionItem, null);
+                                    mocThirdPartyAPIService,
+                                    passportFormData,
+                                    sessionItem,
+                                    null,
+                                    Strategy.NO_CHANGE);
                         });
 
         assertEquals(expectedReturnedException.getStatusCode(), thrownException.getStatusCode());

--- a/lib-dvad/src/test/java/uk/gov/di/ipv/cri/passport/library/dvad/services/DvadThirdPartyAPIServiceTest.java
+++ b/lib-dvad/src/test/java/uk/gov/di/ipv/cri/passport/library/dvad/services/DvadThirdPartyAPIServiceTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.passport.library.PassportFormTestDataGenerator;
 import uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportFormData;
+import uk.gov.di.ipv.cri.passport.library.domain.Strategy;
 import uk.gov.di.ipv.cri.passport.library.domain.result.ThirdPartyAPIResult;
 import uk.gov.di.ipv.cri.passport.library.dvad.domain.response.AccessTokenResponse;
 import uk.gov.di.ipv.cri.passport.library.dvad.domain.response.GraphQLAPIResponse;
@@ -77,26 +78,6 @@ class DvadThirdPartyAPIServiceTest {
 
         // Mocks out the creation of all endpoints to allow mocking the endpoint responses without
         // calling them for real
-        when(mockDvadAPIEndpointFactory.createHealthCheckService(
-                        eq(mockCloseableHttpClient),
-                        any(RequestConfig.class),
-                        eq(realObjectMapper),
-                        eq(mockEventProbe)))
-                .thenReturn(mockHealthCheckService);
-
-        when(mockDvadAPIEndpointFactory.createTokenRequestService(
-                        eq(mockCloseableHttpClient),
-                        any(RequestConfig.class),
-                        eq(realObjectMapper),
-                        eq(mockEventProbe)))
-                .thenReturn(mockTokenRequestService);
-
-        when(mockDvadAPIEndpointFactory.createGraphQLRequestService(
-                        eq(mockCloseableHttpClient),
-                        any(RequestConfig.class),
-                        eq(realObjectMapper),
-                        eq(mockEventProbe)))
-                .thenReturn(mockGraphQLRequestService);
 
         dvadThirdPartyAPIServiceTest =
                 new DvadThirdPartyAPIService(
@@ -119,6 +100,30 @@ class DvadThirdPartyAPIServiceTest {
     })
     void shouldReturnIsValidTrueGivenValidDataAndAllThirdPartyEndpointsRespond(
             boolean validationResult) throws OAuthErrorResponseException {
+
+        when(mockDvadAPIEndpointFactory.createHealthCheckService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockHealthCheckService);
+
+        when(mockDvadAPIEndpointFactory.createTokenRequestService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockTokenRequestService);
+
+        when(mockDvadAPIEndpointFactory.createGraphQLRequestService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockGraphQLRequestService);
 
         boolean expectedIsValid = validationResult;
 
@@ -176,7 +181,8 @@ class DvadThirdPartyAPIServiceTest {
                         eq(passportFormData)))
                 .thenReturn(testGraphQLServiceResult);
 
-        ThirdPartyAPIResult result = dvadThirdPartyAPIServiceTest.performCheck(passportFormData);
+        ThirdPartyAPIResult result =
+                dvadThirdPartyAPIServiceTest.performCheck(passportFormData, Strategy.NO_CHANGE);
 
         // Using the correct third party API?
         Assertions.assertEquals(
@@ -204,6 +210,30 @@ class DvadThirdPartyAPIServiceTest {
     })
     void shouldThrowOAuthErrorResponseExceptionWhenAPIResponseContainsErrorsOrIsEmpty(
             boolean errors) throws OAuthErrorResponseException {
+
+        when(mockDvadAPIEndpointFactory.createHealthCheckService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockHealthCheckService);
+
+        when(mockDvadAPIEndpointFactory.createTokenRequestService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockTokenRequestService);
+
+        when(mockDvadAPIEndpointFactory.createGraphQLRequestService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockGraphQLRequestService);
 
         PassportFormData passportFormData = PassportFormTestDataGenerator.generate();
 
@@ -269,7 +299,9 @@ class DvadThirdPartyAPIServiceTest {
         OAuthErrorResponseException thrownException =
                 Assertions.assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> dvadThirdPartyAPIServiceTest.performCheck(passportFormData),
+                        () ->
+                                dvadThirdPartyAPIServiceTest.performCheck(
+                                        passportFormData, Strategy.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         Assertions.assertEquals(
@@ -300,6 +332,30 @@ class DvadThirdPartyAPIServiceTest {
     void shouldReturnOAuthErrorResponseExceptionWhenHealthEndpointIsDown()
             throws OAuthErrorResponseException {
 
+        when(mockDvadAPIEndpointFactory.createHealthCheckService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockHealthCheckService);
+
+        when(mockDvadAPIEndpointFactory.createTokenRequestService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockTokenRequestService);
+
+        when(mockDvadAPIEndpointFactory.createGraphQLRequestService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockGraphQLRequestService);
+
         PassportFormData passportFormData = PassportFormTestDataGenerator.generate();
 
         boolean testHealthCheckStatusUp = false;
@@ -317,7 +373,9 @@ class DvadThirdPartyAPIServiceTest {
         OAuthErrorResponseException thrownException =
                 Assertions.assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> dvadThirdPartyAPIServiceTest.performCheck(passportFormData),
+                        () ->
+                                dvadThirdPartyAPIServiceTest.performCheck(
+                                        passportFormData, Strategy.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         Assertions.assertEquals(
@@ -335,6 +393,30 @@ class DvadThirdPartyAPIServiceTest {
     })
     void shouldReturnOAuthErrorResponseExceptionWhenGraphQLResponseFailsValidation(
             String forcedFailure) throws OAuthErrorResponseException {
+
+        when(mockDvadAPIEndpointFactory.createHealthCheckService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockHealthCheckService);
+
+        when(mockDvadAPIEndpointFactory.createTokenRequestService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockTokenRequestService);
+
+        when(mockDvadAPIEndpointFactory.createGraphQLRequestService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.NO_CHANGE)))
+                .thenReturn(mockGraphQLRequestService);
 
         PassportFormData passportFormData = PassportFormTestDataGenerator.generate();
 
@@ -420,7 +502,9 @@ class DvadThirdPartyAPIServiceTest {
         OAuthErrorResponseException thrownException =
                 Assertions.assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> dvadThirdPartyAPIServiceTest.performCheck(passportFormData),
+                        () ->
+                                dvadThirdPartyAPIServiceTest.performCheck(
+                                        passportFormData, Strategy.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         InOrder inOrder = inOrder(mockEventProbe);
@@ -517,6 +601,116 @@ class DvadThirdPartyAPIServiceTest {
                 assertMinimalTestErrorMessageParts(messagePartMap);
                 break;
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "true", // API response ValidationResult true
+        "false" // API response ValidationResult false
+    })
+    void shouldReturnIsValidTrueGivenValidDataAndStrategyEqualsStubAndAllThirdPartyEndpointsRespond(
+            boolean validationResult) throws OAuthErrorResponseException {
+
+        when(mockDvadAPIEndpointFactory.createHealthCheckService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.STUB)))
+                .thenReturn(mockHealthCheckService);
+
+        when(mockDvadAPIEndpointFactory.createTokenRequestService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.STUB)))
+                .thenReturn(mockTokenRequestService);
+
+        when(mockDvadAPIEndpointFactory.createGraphQLRequestService(
+                        eq(mockCloseableHttpClient),
+                        any(RequestConfig.class),
+                        eq(realObjectMapper),
+                        eq(mockEventProbe),
+                        eq(Strategy.STUB)))
+                .thenReturn(mockGraphQLRequestService);
+
+        boolean expectedIsValid = validationResult;
+
+        PassportFormData passportFormData = PassportFormTestDataGenerator.generate();
+
+        // Health service Response
+        boolean testHealthCheckStatusUp = true;
+
+        // Token service Response
+        AccessTokenResponse testValidAccessTokenResponse =
+                AccessTokenResponse.builder()
+                        .accessToken("A_TOKEN_VALUE")
+                        .tokenType("Bearer")
+                        .expiresIn(1800)
+                        .build();
+
+        // Generated a valid api response object to create the api response for this test
+        GraphQLServiceResult testGraphQLServiceResult;
+        GraphQLAPIResponse testGraphQLAPIResponseObject;
+
+        if (expectedIsValid) {
+            testGraphQLAPIResponseObject =
+                    GraphQLAPIResponse.builder()
+                            .data(ResponseDataGenerator.createValidationResultTrueResponseData())
+                            .build();
+        } else {
+            testGraphQLAPIResponseObject =
+                    GraphQLAPIResponse.builder()
+                            .data(ResponseDataGenerator.createValidationResultFalseResponseData())
+                            .build();
+        }
+        testGraphQLServiceResult =
+                GraphQLServiceResult.builder()
+                        .graphQLAPIResponse(testGraphQLAPIResponseObject)
+                        .requestId(UUID.randomUUID().toString())
+                        .build();
+
+        mockDvadAPIHeaderValues();
+
+        when(mockHealthCheckService.checkRemoteApiIsUp(any(DvadAPIHeaderValues.class)))
+                .thenReturn(testHealthCheckStatusUp);
+
+        when(mockTokenRequestService.requestAccessToken(any(DvadAPIHeaderValues.class), eq(true)))
+                .thenReturn(testValidAccessTokenResponse);
+
+        final String TEST_QUERY_STRING = "TEST_QUERY_STRING";
+        when(mockParameterStoreService.getEncryptedParameterValue(
+                        ParameterStoreParameters.HMPO_GRAPHQL_QUERY_STRING))
+                .thenReturn(TEST_QUERY_STRING);
+
+        when(mockGraphQLRequestService.performGraphQLQuery(
+                        eq(testValidAccessTokenResponse),
+                        any(DvadAPIHeaderValues.class),
+                        eq(TEST_QUERY_STRING),
+                        eq(passportFormData)))
+                .thenReturn(testGraphQLServiceResult);
+
+        ThirdPartyAPIResult result =
+                dvadThirdPartyAPIServiceTest.performCheck(passportFormData, Strategy.STUB);
+
+        // Using the correct third party API?
+        Assertions.assertEquals(
+                dvadThirdPartyAPIServiceTest.getServiceName(),
+                DvadThirdPartyAPIService.class.getSimpleName());
+
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe)
+                .counterMetric(
+                        ThirdPartyAPIEndpointMetric.DVAD_GRAPHQL_RESPONSE_TYPE_VALID
+                                .withEndpointPrefix());
+        verifyNoMoreInteractions(mockEventProbe);
+
+        assertNotNull(result);
+        assertNotNull(result.getTransactionId());
+        assertNotNull(result.getFlags());
+
+        Assertions.assertEquals(expectedIsValid, result.isValid());
     }
 
     private void assertClassificationIsStringMessageParts(Map<String, String> messagePartMap) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ParameterStoreParameters.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ParameterStoreParameters.java
@@ -13,6 +13,9 @@ public class ParameterStoreParameters {
     public static final String HMPO_GRAPHQL_QUERY_STRING =
             "HMPODVAD/API/GraphQl/QueryString"; // Non-public
 
+    // temporary parameter, migrate back to original endpoint parameter post MVP
+    public static final String TEST_STRATEGY_HMPO_API_ENDPOINT_URL =
+            "HMPODVAD/API/TestStrategy/EndpointUrl";
     public static final String HMPO_API_ENDPOINT_URL = "HMPODVAD/API/EndpointUrl";
     public static final String HMPO_API_ENDPOINT_HEALTH = "HMPODVAD/API/HealthPath";
     public static final String HMPO_API_ENDPOINT_TOKEN = "HMPODVAD/API/TokenPath";

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/Strategy.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/Strategy.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.cri.passport.library.domain;
+
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public enum Strategy {
+    STUB,
+    UAT,
+    LIVE,
+    NO_CHANGE;
+
+    public static Strategy fromClientIdString(String clientIdString) {
+        return switch (clientIdString) {
+            case "ipv-core-stub" -> STUB; // Legacy core-stub-id
+            case "ipv-core-stub-aws-build" -> STUB;
+            case "ipv-core-stub-aws-prod" -> STUB;
+            case "ipv-core-stub-aws-build_3rdparty" -> UAT;
+            case "ipv-core-stub-aws-prod_3rdparty" -> UAT;
+            case "ipv-core-stub-pre-prod-aws-build" -> LIVE;
+            case "ipv-core" -> LIVE;
+            default -> NO_CHANGE;
+        };
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ParameterStoreService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ParameterStoreService.java
@@ -79,7 +79,7 @@ public class ParameterStoreService {
 
         LOGGER.debug(LOG_MESSAGE_FORMAT, "getAllParametersFromPath", parametersPath);
 
-        return ssmProvider.getMultiple(parametersPath);
+        return ssmProvider.recursive().getMultiple(parametersPath);
     }
 
     public Map<String, String> getAllParametersFromPathWithDecryption(String path) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ThirdPartyAPIService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ThirdPartyAPIService.java
@@ -1,12 +1,13 @@
 package uk.gov.di.ipv.cri.passport.library.service;
 
 import uk.gov.di.ipv.cri.passport.library.domain.PassportFormData;
+import uk.gov.di.ipv.cri.passport.library.domain.Strategy;
 import uk.gov.di.ipv.cri.passport.library.domain.result.ThirdPartyAPIResult;
 import uk.gov.di.ipv.cri.passport.library.exceptions.OAuthErrorResponseException;
 
 public interface ThirdPartyAPIService {
     String getServiceName();
 
-    ThirdPartyAPIResult performCheck(PassportFormData passportFormData)
+    ThirdPartyAPIResult performCheck(PassportFormData passportFormData, Strategy strategy)
             throws OAuthErrorResponseException;
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/ParameterStoreServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/ParameterStoreServiceTest.java
@@ -92,10 +92,12 @@ class ParameterStoreServiceTest {
         String testPath = "TESTPATH/SUBPATH";
         String fullPath = String.format("/%s/%s", PARAMETER_PREFIX, testPath);
 
+        when(mockSSMProvider.recursive()).thenReturn(mockSSMProvider);
         when(mockSSMProvider.getMultiple(fullPath)).thenReturn(testParameterMap);
 
         assertEquals(testParameterMap, parameterStoreService.getAllParametersFromPath(testPath));
 
+        verify(mockSSMProvider).recursive();
         verify(mockSSMProvider).getMultiple(fullPath);
     }
 


### PR DESCRIPTION
### What changed
 - Updated EndpointParameters to have functionality that can pull in Parameters with multiple values in the form of a JSON block. (This means one parameter can have a value for Stub, Uat and Live service)

 - Updated DocumentDataVerification service and checkPassportHandler so that the value selected for parameters with multiple values is conditional on the clientId passed to the CRI from IpvCore/stub.

 - Created an enum for mapping the clientId to a value for routing purposes.

 - Updated tests to reflect above changes

[LIME-983](https://govukverify.atlassian.net/browse/LIME-983)

[LIME-983]: https://govukverify.atlassian.net/browse/LIME-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ