### PR TITLE
LIME-842 adding gradle to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: daily
-      time: "03:00"
-    target-branch: main
-    labels:
-    - dependabot
-    ignore:
-      - dependency-name: "node"
-        versions: ["17.x","18.x","19.x"]
-    commit-message:
-      prefix: BAU
-  - package-ecosystem: docker
+  - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: daily
-      time: "03:00"
+      time: "12:00"
     target-branch: main
     labels:
-    - dependabot
+      - dependabot
     commit-message:
       prefix: BAU
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Dependabot.yml now contains a gradle ecosystem.

### Why did it change

To rely on dependabot to recommend dependency upgrades as we are doing with nvm in the front end.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-842](https://govukverify.atlassian.net/browse/LIME-842)

[LIME-842]: https://govukverify.atlassian.net/browse/LIME-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ