### PR TITLE
LIME-983 - Removing tlsOn Environment variable

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -222,15 +222,6 @@ Mappings:
       integration: "false"
       production: "false"
 
-  # Set as EnvVar on the CheckLambda
-  DVADPerformanceStubEnabledEnvVar:
-    Environment:
-      dev: "true"
-      build: "true"
-      staging: "false"
-      integration: "false"
-      production: "false"
-
 Resources:
 
 ####################################################################
@@ -462,7 +453,6 @@ Resources:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-checkpassport"
           ENVIRONMENT: !Ref Environment
-          DVAD_PERFORMANCE_STUB_IN_USE: !FindInMap [DVADPerformanceStubEnabledEnvVar, Environment, !Ref 'Environment']
           DEV_ENVIRONMENT_ONLY_ENHANCED_DEBUG: !FindInMap [ DevEnvironmentOnlyEnhancedDebugMapping, Environment, !Ref Environment ]
       Policies:
         - DynamoDBWritePolicy:

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ThirdPartyAPIServiceFactory.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/services/ThirdPartyAPIServiceFactory.java
@@ -25,10 +25,6 @@ public class ThirdPartyAPIServiceFactory {
     private static final int STUB = 1;
     private final ThirdPartyAPIService[] thirdPartyAPIServices = new ThirdPartyAPIService[2];
 
-    // TLS On/Off
-    private final boolean tlsOn =
-            !Boolean.parseBoolean(System.getenv("DVAD_PERFORMANCE_STUB_IN_USE"));
-
     public ThirdPartyAPIServiceFactory(ServiceFactory serviceFactory)
             throws JsonProcessingException {
         this.parameterStoreService = serviceFactory.getParameterStoreService();
@@ -45,7 +41,7 @@ public class ThirdPartyAPIServiceFactory {
 
         CloseableHttpClient closeableHttpClient =
                 new DVADCloseableHttpClientFactory()
-                        .getClient(tlsOn, parameterStoreService, clientFactoryService);
+                        .getClient(true, parameterStoreService, clientFactoryService);
 
         // Reduces constructor load in DvadThirdPartyAPIService and allow endpoints to be mocked
         DvadAPIEndpointFactory dvadAPIEndpointFactory =


### PR DESCRIPTION
### What changed

- Removed Performance Stub in use environment variable so that tls on/off is dependent on test strategy route
