### PR TITLE
ips-503 remove rusty action

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -59,13 +59,6 @@ jobs:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@39f63740a9f8622eb9b6755413a31a6013a62a86
-        with:
-          template: ./infrastructure/lambda/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: SAM validate
         working-directory: ./infrastructure/lambda
         run: sam validate --region ${{ env.AWS_REGION }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Removed obsolete and redundant rusty-actions workflow step
 
### Why did it change

This is obsolete and now handled by the dev-platform upload action. Replacing previous PR (https://github.com/govuk-one-login/ipv-cri-uk-passport-api/pull/88)

### Issue tracking

- [IPS-503](https://govukverify.atlassian.net/browse/IPS-503)


[IPS-503]: https://govukverify.atlassian.net/browse/IPS-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ