### PR TITLE
LIME-1201 - Including Opaque KID in JWT headers for VCs

### DIFF
--- a/.github/workflows/run-sonar-scan.yml
+++ b/.github/workflows/run-sonar-scan.yml
@@ -38,10 +38,10 @@ jobs:
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
           path: |
-            */build/jacoco/
-            */build/reports/
-            */lambdas/**/build/reports/
-            */lib*/build/reports/
+            build/jacoco/
+            build/reports/
+            lambdas/**/build/reports/
+            lib*/build/reports/
       - name: Run SonarCloud Analysis
         if: ${{ github.actor != 'dependabot[bot]' }}
         env:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -58,17 +58,17 @@ jobs:
         with:
           name: unit-test-reports
           path: |
-            */build/jacoco/
-            */build/reports/
-            */lambdas/**/build/reports/
-            */lib*/build/reports/
+            build/jacoco/
+            build/reports/
+            lambdas/**/build/reports/
+            lib*/build/reports/
           retention-days: 5
       - name: Cache Unit Test Reports
         uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
           path: |
-            */build/jacoco/
-            */build/reports/
-            */lambdas/**/build/reports/
-            */lib*/build/reports/
+            build/jacoco/
+            build/reports/
+            lambdas/**/build/reports/
+            lib*/build/reports/

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
 		// cri_common_lib dependencies should match the ipv-cri-lib version
 		// Workaround until dependency resolution is fixed.
 		// ---------------------------------------------------------
-		cri_common_lib_version             : "3.0.2",
+		cri_common_lib_version             : "3.0.5",
 
 		// AWS SDK
 		aws_sdk_version                    : "2.26.16",
@@ -86,8 +86,8 @@ sonar {
 		property "sonar.organization", "govuk-one-login"
 		property "sonar.host.url", "https://sonarcloud.io"
 		property "sonar.java.coveragePlugin", "jacoco"
-		property "sonar.coverage.jacoco.xmlReportPath", "${buildDir}/reports/jacoco/reports/reports.xml"
-		property "sonar.dependencyCheck.htmlReportPath", "${buildDir}/reports/dependency-check-report.html"
+		property "sonar.coverage.jacoco.xmlReportPath", layout.buildDirectory.file("reports/jacoco/reports/reports.xml")
+		property "sonar.dependencyCheck.htmlReportPath", layout.buildDirectory.file("reports/dependency-check-report.html")
 	}
 }
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -244,18 +244,23 @@ Mappings:
     dev:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
+      IncludeKidInVc: "true"
     build:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
+      IncludeKidInVc: "false"
     staging:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
+      IncludeKidInVc: "false"
     integration:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
+      IncludeKidInVc: "false"
     production:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
+      IncludeKidInVc: "false"
 
 Resources:
 
@@ -600,6 +605,7 @@ Resources:
           ENVIRONMENT: !Ref Environment
           ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED: !FindInMap [ FeatureFlagMapping, !Ref Environment, VcExpiryRemoved ]
           ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID: !FindInMap [ FeatureFlagMapping, !Ref Environment, VcContainsUniqueIdMapping ]
+          INCLUDE_VC_KID: !FindInMap [ FeatureFlagMapping, !Ref Environment, IncludeKidInVc ]
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
@@ -642,6 +648,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiableCredentialKmsSigningKeyId"
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -82,11 +82,6 @@ Conditions:
     - !Ref Environment
     - production
 
-  # This is a special case fix to avoid setting this environment wide feature flag in dev.
-  # As it becomes owned by the first stack using it. Remove once the feature flag is removed and feature is permanent.
-  OverrideSettingOfEnvironmentWideFeatureFlag: !Equals
-    - !Ref Environment
-    - dev
   IsNotCRIDevEnv:
     Fn::Not:
       - Fn::Equals:
@@ -203,22 +198,6 @@ Mappings:
       staging: 1
       integration: 1
       production: 1
-
-  VcExpiryRemoved:
-    Environment:
-      dev: "true"
-      build: "true"
-      staging: "true"
-      integration: "true"
-      production: "true"
-
-  VcContainsUniqueIdMapping:
-    Environment:
-      dev: "true"
-      build: "true"
-      staging: "true"
-      integration: "true"
-      production: "true"
 
   # VC Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
   JwtTtlUnitMapping:
@@ -867,25 +846,6 @@ Resources:
 # Parameters                                                       #
 #                                                                  #
 ####################################################################
-
-  ParameterReleaseFlagsVcExpiryRemoved:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !If
-        - OverrideSettingOfEnvironmentWideFeatureFlag
-        - !Sub "/${AWS::StackName}/release-flags-vc-expiry-removed-not-used-in-dev"
-        - !Sub "/release-flags/vc-expiry-removed"
-      Value: !FindInMap [ VcExpiryRemoved, Environment, !Ref Environment ]
-      Type: String
-      Description: Expiry date release toggle
-
-  ReleaseFlagsVcContainsUniqueIdParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/release-flags/vc-contains-unique-id"
-      Value: !FindInMap [ VcContainsUniqueIdMapping, Environment, !Ref Environment ]
-      Type: String
-      Description: Verifiable Credential Contains UniqueId Mapping
 
   ParameterDocumentCheckResultTableName:
     Type: AWS::SSM::Parameter

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialService.java
@@ -15,6 +15,7 @@ import uk.gov.di.ipv.cri.passport.library.persistence.DocumentCheckResultItem;
 import uk.gov.di.ipv.cri.passport.library.service.ParameterStoreService;
 import uk.gov.di.ipv.cri.passport.library.service.ServiceFactory;
 
+import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -51,7 +52,7 @@ public class VerifiableCredentialService {
             String subject,
             DocumentCheckResultItem documentCheckResultItem,
             PersonIdentityDetailed personIdentityDetailed)
-            throws JOSEException {
+            throws JOSEException, NoSuchAlgorithmException {
         long jwtTtl = commonLibConfigurationService.getMaxJwtTtl();
 
         ChronoUnit jwtTtlUnit =
@@ -73,7 +74,20 @@ public class VerifiableCredentialService {
                         .verifiableCredentialEvidence(calculateEvidence(documentCheckResultItem))
                         .build();
 
-        return signedJwtFactory.createSignedJwt(claimsSet);
+        SignedJWT signedJwt = null;
+        if (Boolean.parseBoolean(System.getenv("INCLUDE_VC_KID"))) {
+            String issuer =
+                    commonLibConfigurationService.getCommonParameterValue(
+                            "verifiable-credential/issuer");
+            String kmsSigningKeyId =
+                    commonLibConfigurationService.getCommonParameterValue(
+                            "verifiableCredentialKmsSigningKeyId");
+            signedJwt = signedJwtFactory.createSignedJwt(claimsSet, issuer, kmsSigningKeyId);
+        } else {
+            signedJwt = signedJwtFactory.createSignedJwt(claimsSet);
+        }
+
+        return signedJwt;
     }
 
     private Object[] convertPassport(DocumentCheckResultItem documentCheckResultItem) {

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/handler/IssueCredentialHandlerTest.java
@@ -46,7 +46,6 @@ import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-import java.net.MalformedURLException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.UUID;
@@ -103,7 +102,7 @@ class IssueCredentialHandlerTest {
 
     @Test
     void shouldReturn200OkWhenIssueCredentialRequestIsValid()
-            throws JOSEException, SqsException, MalformedURLException, NoSuchAlgorithmException {
+            throws JOSEException, SqsException, NoSuchAlgorithmException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken();
         event.withHeaders(
@@ -172,7 +171,7 @@ class IssueCredentialHandlerTest {
 
     @Test
     void shouldReturn200OkWhenIssueCredentialRequestIsValidAndIncludeKIdIsTrue()
-            throws JOSEException, SqsException, MalformedURLException, NoSuchAlgorithmException {
+            throws JOSEException, SqsException, NoSuchAlgorithmException {
         environmentVariables.set("INCLUDE_VC_KID", "true");
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -243,8 +242,7 @@ class IssueCredentialHandlerTest {
 
     @Test
     void shouldThrowJOSEExceptionWhenGenerateVerifiableCredentialIsMalformed()
-            throws JOSEException, SqsException, JsonProcessingException, MalformedURLException,
-                    NoSuchAlgorithmException {
+            throws JOSEException, SqsException, JsonProcessingException, NoSuchAlgorithmException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken();
         event.withHeaders(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/handler/IssueCredentialHandlerTest.java
@@ -46,6 +46,8 @@ import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
+import java.net.MalformedURLException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.UUID;
 
@@ -71,6 +73,7 @@ class IssueCredentialHandlerTest {
     @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     public static final String REQUEST_SUBJECT = "subject";
+
     @Mock private Context mockLambdaContext;
 
     @Mock private ServiceFactory mockServiceFactory;
@@ -99,7 +102,79 @@ class IssueCredentialHandlerTest {
     }
 
     @Test
-    void shouldReturn200OkWhenIssueCredentialRequestIsValid() throws JOSEException, SqsException {
+    void shouldReturn200OkWhenIssueCredentialRequestIsValid()
+            throws JOSEException, SqsException, MalformedURLException, NoSuchAlgorithmException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        AccessToken accessToken = new BearerAccessToken();
+        event.withHeaders(
+                Map.of(
+                        IssueCredentialHandler.AUTHORIZATION_HEADER_KEY,
+                        accessToken.toAuthorizationHeader()));
+        setRequestBodyAsPlainJWT(event);
+
+        PersonIdentityDetailed personIdentityDetailed =
+                PersonIdentityDetailedHelperMapper.passportFormDataToAuditRestrictedFormat(
+                        PassportFormTestDataGenerator.generate());
+        SessionItem sessionItem = new SessionItem();
+        sessionItem.setSessionId(UUID.randomUUID());
+        DocumentCheckResultItem resultItem =
+                DocumentCheckTestDataGenerator.generateUnverifiedResultItem();
+
+        when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(sessionItem);
+        when(mockPersonIdentityService.getPersonIdentityDetailed(sessionItem.getSessionId()))
+                .thenReturn(personIdentityDetailed);
+        when(mockDocumentCheckResultStore.getItem(String.valueOf(sessionItem.getSessionId())))
+                .thenReturn(resultItem);
+        when(mockVerifiableCredentialService.generateSignedVerifiableCredentialJwt(
+                        sessionItem.getSubject(), resultItem, personIdentityDetailed))
+                .thenReturn(mock(SignedJWT.class));
+
+        doNothing()
+                .when(mockAuditService)
+                .sendAuditEvent(
+                        eq(AuditEventType.VC_ISSUED),
+                        any(AuditEventContext.class),
+                        any(VCISSDocumentCheckAuditExtension.class));
+
+        when(mockLambdaContext.getFunctionName()).thenReturn("functionName");
+        when(mockLambdaContext.getFunctionVersion()).thenReturn("1.0");
+        APIGatewayProxyResponseEvent responseEvent =
+                issueCredentialHandler.handleRequest(event, mockLambdaContext);
+
+        verify(mockSessionService).getSessionByAccessToken(accessToken);
+        verify(mockDocumentCheckResultStore).getItem(String.valueOf(sessionItem.getSessionId()));
+        verify(mockPersonIdentityService).getPersonIdentityDetailed(any());
+        verify(mockVerifiableCredentialService)
+                .generateSignedVerifiableCredentialJwt(
+                        sessionItem.getSubject(), resultItem, personIdentityDetailed);
+
+        InOrder inOrder = inOrder(mockEventProbe, mockAuditService);
+        inOrder.verify(mockEventProbe)
+                .counterMetric(eq(LAMBDA_ISSUE_CREDENTIAL_FUNCTION_INIT_DURATION), anyDouble());
+        inOrder.verify(mockAuditService)
+                .sendAuditEvent(
+                        eq(AuditEventType.VC_ISSUED),
+                        any(AuditEventContext.class),
+                        any(VCISSDocumentCheckAuditExtension.class));
+        inOrder.verify(mockEventProbe)
+                .counterMetric(PASSPORT_CI_PREFIX + resultItem.getContraIndicators().get(0));
+        inOrder.verify(mockAuditService)
+                .sendAuditEvent(eq(AuditEventType.END), any(AuditEventContext.class));
+        inOrder.verify(mockEventProbe).counterMetric(LAMBDA_ISSUE_CREDENTIAL_COMPLETED_OK);
+        verifyNoMoreInteractions(mockEventProbe);
+        verifyNoMoreInteractions(mockAuditService);
+
+        assertEquals(
+                ContentType.APPLICATION_JWT.getType(),
+                responseEvent.getHeaders().get("Content-Type"));
+        assertEquals(HttpStatusCode.OK, responseEvent.getStatusCode());
+    }
+
+    @Test
+    void shouldReturn200OkWhenIssueCredentialRequestIsValidAndIncludeKIdIsTrue()
+            throws JOSEException, SqsException, MalformedURLException, NoSuchAlgorithmException {
+        environmentVariables.set("INCLUDE_VC_KID", "true");
+
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken();
         event.withHeaders(
@@ -168,7 +243,8 @@ class IssueCredentialHandlerTest {
 
     @Test
     void shouldThrowJOSEExceptionWhenGenerateVerifiableCredentialIsMalformed()
-            throws JOSEException, SqsException, JsonProcessingException {
+            throws JOSEException, SqsException, JsonProcessingException, MalformedURLException,
+                    NoSuchAlgorithmException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken();
         event.withHeaders(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java
@@ -123,6 +123,7 @@ class IssueCredentialHandlerTest {
 
         environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED, true);
         environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, true);
+        environmentVariables.set("INCLUDE_VC_KID", false);
 
         mockServiceFactoryBehaviour();
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/utils/PreLambdaHandler.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/utils/PreLambdaHandler.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -99,16 +98,15 @@ class PreLambdaHandler implements HttpHandler {
         return pathParams;
     }
 
-    public static Map<String, String> getQueryStringParams(URI url)
-            throws UnsupportedEncodingException {
+    public static Map<String, String> getQueryStringParams(URI url) {
         Map<String, String> query_pairs = new HashMap<>();
         String query = url.getQuery();
         String[] pairs = query.split("&");
         for (String pair : pairs) {
             int idx = pair.indexOf("=");
             query_pairs.put(
-                    URLDecoder.decode(pair.substring(0, idx), "UTF-8"),
-                    URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
+                    URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8),
+                    URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
         }
         return query_pairs;
     }
@@ -213,6 +211,11 @@ class PreLambdaHandler implements HttpHandler {
         TreeMap<String, Object> test = new TreeMap<>();
         test.put("typ", jwt.getHeader().getType().getType());
         test.put("alg", jwt.getHeader().getAlgorithm().getName());
+
+        String keyID = ((JWSHeader) jwt.getHeader()).getKeyID();
+        if (keyID != null) {
+            test.put("kid", keyID);
+        }
 
         Base64URL jwtHeader = Base64URL.encode(new ObjectMapper().writeValueAsString(test));
         String[] serialize = signedJWT.serialize().split("\\.");

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
@@ -29,7 +30,11 @@ import uk.gov.di.ipv.cri.passport.library.helpers.PersonIdentityDetailedHelperMa
 import uk.gov.di.ipv.cri.passport.library.persistence.DocumentCheckResultItem;
 import uk.gov.di.ipv.cri.passport.library.service.ParameterStoreService;
 import uk.gov.di.ipv.cri.passport.library.service.ServiceFactory;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
+import java.net.MalformedURLException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.text.ParseException;
@@ -54,10 +59,18 @@ import static uk.gov.di.ipv.cri.passport.library.config.GlobalConstants.UK_ICAO_
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.MAX_JWT_TTL_UNIT;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
 class VerifiableCredentialServiceTest implements VerifiableCredentialServiceTestFixtures {
     private static final Logger LOGGER = LogManager.getLogger();
+    @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
-    private final String UNIT_TEST_VC_ISSUER = "UNIT_TEST_VC_ISSUER";
+    @SuppressWarnings("java:S116")
+    private final String UNIT_TEST_VC_KEYID = "UNIT_TEST_VC_KEYID";
+
+    @SuppressWarnings("java:S116")
+    private final String UNIT_TEST_VC_ISSUER = "https://UNIT_TEST_VC_ISSUER";
+
+    @SuppressWarnings("java:S116")
     private final String UNIT_TEST_SUBJECT = "urn:fdc:12345678";
 
     @Mock private ServiceFactory mockServiceFactory;
@@ -72,27 +85,36 @@ class VerifiableCredentialServiceTest implements VerifiableCredentialServiceTest
 
     @BeforeEach
     void setup() throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException {
+        mockServiceFactoryBehaviour();
 
         JWSSigner jwsSigner = new ECDSASigner(getPrivateKey());
 
-        mockServiceFactoryBehaviour();
-
         verifiableCredentialService =
                 new VerifiableCredentialService(mockServiceFactory, jwsSigner);
+        System.out.println(environmentVariables.getVariables());
     }
 
     @ParameterizedTest
     @CsvSource({
-        "3600, SECONDS, true", // 1 hour, Verified VC
-        "1814400, SECONDS, true", // 3 weeks, Verified VC
-        "15780000, SECONDS, true", // 6 months, Verified VC
-        "3600, SECONDS, false", // 1 hour, Unverified VC
-        "1814400, SECONDS, false", // 3 weeks, Unverified VC
-        "15780000, SECONDS, false", // 6 months, Unverified VC
+        "3600, SECONDS, true, true", // 1 hour, Verified VC, IncludeKidInVc
+        "1814400, SECONDS, true, true", // 3 weeks, Verified VC, IncludeKidInVc
+        "15780000, SECONDS, true, true", // 6 months, Verified VC, IncludeKidInVc
+        "3600, SECONDS, false, true", // 1 hour, Unverified VC, IncludeKidInVc
+        "1814400, SECONDS, false, true", // 3 weeks, Unverified VC, IncludeKidInVc
+        "15780000, SECONDS, false, true", // 6 months, Unverified VC, IncludeKidInVc
+        "3600, SECONDS, true, false", // 1 hour, Verified VC
+        "1814400, SECONDS, true, false", // 3 weeks, Verified VC
+        "15780000, SECONDS, true, false", // 6 months, Verified VC
+        "3600, SECONDS, false, false", // 1 hour, Unverified VC
+        "1814400, SECONDS, false, false", // 3 weeks, Unverified VC
+        "15780000, SECONDS, false, false", // 6 months, Unverified VC
     })
     void shouldGenerateSignedVerifiableCredentialJWTWithMaxTTL(
-            String maxJwtTtl, String maxJwtTtlUnit, boolean verified)
-            throws JOSEException, JsonProcessingException, ParseException {
+            String maxJwtTtl, String maxJwtTtlUnit, boolean verified, boolean includeKidInVC)
+            throws JOSEException, JsonProcessingException, ParseException, MalformedURLException,
+                    NoSuchAlgorithmException {
+
+        environmentVariables.set("INCLUDE_VC_KID", includeKidInVC);
 
         final long TTL = Long.parseLong(maxJwtTtl);
         final String JWT_TTL_UNIT = maxJwtTtlUnit;
@@ -114,6 +136,16 @@ class VerifiableCredentialServiceTest implements VerifiableCredentialServiceTest
             documentCheckResultItem =
                     DocumentCheckTestDataGenerator.generateUnverifiedResultItem(
                             sessionID, passportFormData.getPassportNumber());
+        }
+
+        if (includeKidInVC) {
+            when(mockCommonLibConfigurationService.getCommonParameterValue(
+                            "verifiableCredentialKmsSigningKeyId"))
+                    .thenReturn(UNIT_TEST_VC_KEYID);
+
+            when(mockCommonLibConfigurationService.getCommonParameterValue(
+                            "verifiable-credential/issuer"))
+                    .thenReturn(UNIT_TEST_VC_ISSUER);
         }
 
         when(mockCommonLibConfigurationService.getMaxJwtTtl()).thenReturn(TTL);
@@ -139,6 +171,19 @@ class VerifiableCredentialServiceTest implements VerifiableCredentialServiceTest
                         .withDefaultPrettyPrinter()
                         .writeValueAsString(generatedClaims);
         LOGGER.info(jsonGeneratedClaims);
+
+        JWSHeader generatedJWSHeader = null;
+        if (includeKidInVC) {
+            generatedJWSHeader = signedJWT.getHeader();
+            String[] jwsHeaderParts = generatedJWSHeader.getKeyID().split(":");
+
+            String[] issuerHash = jwsHeaderParts[2].split("#");
+            String actualIssuer = issuerHash[0];
+
+            assertEquals("did", jwsHeaderParts[0]);
+            assertEquals("web", jwsHeaderParts[1]);
+            assertEquals("UNIT_TEST_VC_ISSUER", actualIssuer);
+        }
 
         JsonNode claimsSet = realObjectMapper.readTree(generatedClaims.toString());
         assertNotNull(claimsSet);

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
@@ -34,7 +34,6 @@ import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-import java.net.MalformedURLException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.text.ParseException;
@@ -111,7 +110,7 @@ class VerifiableCredentialServiceTest implements VerifiableCredentialServiceTest
     })
     void shouldGenerateSignedVerifiableCredentialJWTWithMaxTTL(
             String maxJwtTtl, String maxJwtTtlUnit, boolean verified, boolean includeKidInVC)
-            throws JOSEException, JsonProcessingException, ParseException, MalformedURLException,
+            throws JOSEException, JsonProcessingException, ParseException,
                     NoSuchAlgorithmException {
 
         environmentVariables.set("INCLUDE_VC_KID", includeKidInVC);


### PR DESCRIPTION
### What changed
Updated verifiableCredentialService to use updated jwtSigning implementation and include kid in jwt headers