### PR TITLE
LIME-1212 Remove references to cucumber publish

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/runners/TestRunner.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/runners/TestRunner.java
@@ -6,7 +6,6 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        publish = false,
         plugin = "io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm",
         features = "src/test/resources/features",
         glue = "uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions",

--- a/acceptance-tests/src/test/resources/cucumber.properties
+++ b/acceptance-tests/src/test/resources/cucumber.properties
@@ -1,2 +1,1 @@
 cucumber.publish.quiet=false
-cucumber.publish.enabled=false


### PR DESCRIPTION
## Proposed changes

### What changed

Remove cucumber publish variable

### Why did it change

A previous PR set the publish value to false to disable the report publishing.
The presence of the variable is however is still being flagged.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1212](https://govukverify.atlassian.net/browse/LIME-1212)

[LIME-1212]: https://govukverify.atlassian.net/browse/LIME-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ