### PR TITLE
[LIME-1114] Added check for incoming session_id header is not null

### DIFF
--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
@@ -173,6 +173,11 @@ public class CheckPassportHandler
 
             Map<String, String> requestHeaders = input.getHeaders();
             String sessionId = requestHeaders.get("session_id");
+
+            if (sessionId == null) {
+                throw new SessionNotFoundException("Session ID not found in headers");
+            }
+
             LOGGER.info("Extracting session from header ID {}", sessionId);
             var sessionItem = sessionService.validateSessionId(sessionId);
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/handler/IssueCredentialHandler.java
@@ -166,6 +166,10 @@ public class IssueCredentialHandler
             LOGGER.info("Validating access token...");
             var accessToken = validateInputHeaderBearerToken(input.getHeaders());
             var sessionItem = this.sessionService.getSessionByAccessToken(accessToken);
+
+            if (sessionItem == null || sessionItem.getSessionId() == null) {
+                throw new SessionNotFoundException("Session not found in headers");
+            }
             LOGGER.info("Extracted session from session store ID {}", sessionItem.getSessionId());
 
             LOGGER.info("Retrieving identity details and document check results...");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Add null session_id check to lambda handlers in passport CRI.

### What changed

Added null check to CheckPassportHandler and IssueCredentialHandler to throw a SessionNotFoundException if a session is not found in the header.
Relevant unit test were added to CheckPassportHandlerTest and  IssueCredentialHandlerTest to maintain code coverage.

### Why did it change

Fix for bug where the session could be passed in as null from the front end. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1114](https://govukverify.atlassian.net/browse/LIME-1114)

PR for equivalent changes in dl CRI has been completed [here](https://github.com/govuk-one-login/ipv-cri-dl-api/pull/234)
PR for equivalent changes in fraud CRI has been completed [here](https://github.com/govuk-one-login/ipv-cri-fraud-api/pull/326)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1114]: https://govukverify.atlassian.net/browse/LIME-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ