### PR TITLE
LIME-1114: Added new API Acceptance tests

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportAPIStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportAPIStepDefs.java
@@ -40,6 +40,15 @@ public class PassportAPIStepDefs extends PassportAPIPage {
     }
 
     @When(
+            "Passport user sends a POST request to Passport endpoint with a invalid (.*) using jsonRequest (.*)$")
+    public void passport_user_sends_a_post_request_to_passport_end_point_with_invalid_sessionId(
+            String invalidHeaderValue, String passportJsonRequestBody)
+            throws IOException, InterruptedException, NoSuchFieldException, IllegalAccessException {
+        postRequestToPassportEndpointWithInvalidSessionId(
+                invalidHeaderValue, passportJsonRequestBody);
+    }
+
+    @When(
             "Passport user sends a editable POST request to Passport endpoint using jsonRequest (.*) with edited fields (.*)$")
     public void passport_user_sends_a_post_request_to_passport_end_point(
             String passportJsonRequestBody, String jsonEdits)
@@ -67,6 +76,13 @@ public class PassportAPIStepDefs extends PassportAPIPage {
     public void user_requests_passport_vc()
             throws IOException, InterruptedException, ParseException {
         postRequestToPassportVCEndpoint();
+    }
+
+    @Then(
+            "User requests Passport CRI VC from the Credential Issuer Endpoint with a invalid Bearer Token value")
+    public void user_requests_passport_vc_with_invalid_headers()
+            throws IOException, InterruptedException {
+        postRequestToPassportVCEndpointWithInvalidAuthCode();
     }
 
     @And("Passport VC should contain validityScore (.*) and strengthScore (.*)$")

--- a/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/passport/PassportCRIAPI.feature
@@ -55,3 +55,26 @@ Feature: Passport CRI API
       |PassportJsonPayload              | CI  |  Scenario |
       |PassportInvalidCI1JsonPayload    | D01 |  3        |
       |PassportInvalidCI2JsonPayload    | D01 |  4        |
+
+  @hmpoDVAD @pre-merge @dev
+  Scenario Outline: Passport Journey Un-Happy path with invalid sessionId on Passport Endpoint
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
+    And Passport user sends a POST request to session endpoint
+    And Passport user gets a session-id
+    When Passport user sends a POST request to Passport endpoint with a invalid <invalidHeaderValue> using jsonRequest PassportValidKennethJsonPayload
+    Examples:
+      |invalidHeaderValue              |
+      | mismatchSessionId               |
+      | malformedSessionId             |
+      | missingSessionId               |
+      | noSessionHeader                |
+
+  @hmpoDVAD @pre-merge @dev
+  Scenario: Passport Journey Un-Happy path with invalid authCode on Credential Issuer Endpoint
+    Given Passport user has the user identity in the form of a signed JWT string for CRI Id passport-v1-cri-dev and row number 6
+    And Passport user sends a POST request to session endpoint
+    And Passport user gets a session-id
+    When Passport user sends a POST request to Passport endpoint using jsonRequest PassportValidKennethJsonPayload
+    And Passport user gets authorisation code
+    And Passport user sends a POST request to Access Token endpoint passport-v1-cri-dev
+    Then User requests Passport CRI VC from the Credential Issuer Endpoint with a invalid Bearer Token value


### PR DESCRIPTION
to check that when a invalid sessionid is sent to the driving licence endpoint, or authcode is sent in credential issuer endpoint

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-1114] PR Title` -->

## Proposed changes

### What changed
Added new acceptance-tests to Passport Api tests
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To add coverage to the changes made in LIME-1114 around incoming session_id header is not null
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1114](https://govukverify.atlassian.net/browse/LIME-1114)

### Other considerations
New Test added:
![image](https://github.com/user-attachments/assets/01ba12a9-f425-402b-91ae-b40bfe96a70c)

New Test Passing locally in Dev: 
![image](https://github.com/user-attachments/assets/3a9e75a4-c0d9-494d-bf4f-e23e4d9088bf)

Pre-merge test passing locally in Dev:
![image](https://github.com/user-attachments/assets/3b5e722b-2347-44af-88e4-c4573c71d089)


<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1114]: https://govukverify.atlassian.net/browse/LIME-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ