### PR TITLE
[LIME-1114] Added sessionID validation UUID check

### DIFF
--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
@@ -45,6 +45,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_EXPIRED;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_FOUND;
@@ -174,7 +175,7 @@ public class CheckPassportHandler
             Map<String, String> requestHeaders = input.getHeaders();
             String sessionId = requestHeaders.get("session_id");
 
-            if (sessionId == null) {
+            if (sessionId == null || sessionIdIsNotUUID(sessionId)) {
                 throw new SessionNotFoundException("Session ID not found in headers");
             }
 
@@ -311,6 +312,13 @@ public class CheckPassportHandler
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
                     new CommonExpressOAuthError(OAuth2Error.SERVER_ERROR));
         }
+    }
+
+    public boolean sessionIdIsNotUUID(String sessionId) {
+        Pattern uuidRegex =
+                Pattern.compile(
+                        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+        return !uuidRegex.matcher(sessionId).matches();
     }
 
     private boolean determineVerificationRetryStatus(

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandlerTest.java
@@ -611,6 +611,43 @@ class CheckPassportHandlerTest {
                 oauthErrorNode.get("error_description").textValue()); // error description
     }
 
+    @Test
+    void handleResponseShouldThrowExceptionWhenSessionIdIsInvalidUUID()
+            throws JsonProcessingException {
+        APIGatewayProxyRequestEvent mockRequestEvent =
+                Mockito.mock(APIGatewayProxyRequestEvent.class);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("session_id", "invalid");
+
+        when(mockRequestEvent.getHeaders()).thenReturn(headers);
+
+        APIGatewayProxyResponseEvent responseEvent =
+                checkPassportHandler.handleRequest(mockRequestEvent, mockLambdaContext);
+
+        JsonNode responseTreeRootNode = new ObjectMapper().readTree(responseEvent.getBody());
+        JsonNode oauthErrorNode = responseTreeRootNode.get("oauth_error");
+
+        CommonExpressOAuthError expectedObject =
+                new CommonExpressOAuthError(
+                        OAuth2Error.ACCESS_DENIED, SESSION_NOT_FOUND.getMessage());
+
+        assertNotNull(responseEvent);
+        assertNotNull(responseTreeRootNode);
+        assertNotNull(oauthErrorNode);
+        assertEquals(HttpStatusCode.FORBIDDEN, responseEvent.getStatusCode());
+
+        assertEquals(
+                "oauth_error",
+                responseTreeRootNode.fieldNames().next().toString()); // Root Node Name
+        assertEquals(
+                expectedObject.getError().get("error"),
+                oauthErrorNode.get("error").textValue()); // error
+        assertEquals(
+                expectedObject.getError().get("error_description"),
+                oauthErrorNode.get("error_description").textValue()); // error description
+    }
+
     private void mockServiceFactoryBehaviour() {
         when(mockServiceFactory.getObjectMapper()).thenReturn(realObjectMapper);
         when(mockServiceFactory.getEventProbe()).thenReturn(mockEventProbe);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Issue during testing where an empty value for the session_id header was returning Unexpected server error.
Update CheckPassportHandler.java to use UUID so it catches incorrect strings/special chars

### What changed

Added UUID check for sessionID in CheckPassportHandler.java 
Added unit test for invalid sessionID in CheckPassportHandlerTest.java 

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1114](https://govukverify.atlassian.net/browse/LIME-1114)
- [LIME-1289](https://govukverify.atlassian.net/browse/LIME-1289)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1114]: https://govukverify.atlassian.net/browse/LIME-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1289]: https://govukverify.atlassian.net/browse/LIME-1289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ