### PR TITLE
LIME-1169 Set log group retention in days to 30 for all log groups

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -128,73 +132,85 @@
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "b35d40d12423628d17dba54252182396a1d90103",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 400
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "7d46dde65b8301c1eaf84f99441a92be55bcf5f1",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 401
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "a24621f1e7f2aa3be1b3fd8aa158bb666fef7da0",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 405
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "acdb3814fc474a0eff4b8a0c471dd3d588409995",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 406
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "fe2031f80d50c6fe6902a22233162a77f5e72952",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 410
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "bd51a1e663fbdda216f4a0af85e7889b1a7acae6",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 412
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "4189dcfc39ca9e23b297ffbbae6f8fc2065e385f",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 413
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "83d2570a5fba078cbc5d2d6167a3c95b096222aa",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 418
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "3f80e3787a4e138a7d4dc0ded3f5523bdfe65af3",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 419
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "7c186605d87b2294f2353966611a68619729a9f3",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 423
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "180a11b0b86b1a47d9fd1caf3a38e217f8585958",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 424
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "c29bfc272e1012aacc9dcad023af303f34e8b08a",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 425
       }
     ],
     "acceptance-tests/src/test/resources/axe.min.js": [
@@ -202,7 +218,8 @@
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/resources/axe.min.js",
         "hashed_secret": "1d278d3c888d1a2fa7eed622bfc02927ce4049af",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 12
       }
     ],
     "infrastructure/lambda/public-api.yaml": [
@@ -210,13 +227,15 @@
         "type": "JSON Web Token",
         "filename": "infrastructure/lambda/public-api.yaml",
         "hashed_secret": "01613fb1bb441c88d5e6773e2813ee026ad5b928",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 34
       },
       {
         "type": "JSON Web Token",
         "filename": "infrastructure/lambda/public-api.yaml",
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 95
       }
     ],
     "infrastructure/lambda/template.yaml": [
@@ -224,49 +243,57 @@
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 136
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 139
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 142
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 145
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 148
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 165
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 171
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 179
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java": [
@@ -274,13 +301,15 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java",
         "hashed_secret": "41c5ebe18c2f4a118ee2798dca00c8ca2f981149",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 135
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java",
         "hashed_secret": "3e4372459809fa2f4f46af84291360a04ead6573",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 136
       }
     ],
     "lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/CertAndKeyTestFixtures.java": [
@@ -288,19 +317,22 @@
         "type": "Base64 High Entropy String",
         "filename": "lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/CertAndKeyTestFixtures.java",
         "hashed_secret": "bfa1b54631f691aa9d9937866f6e21270fd7deec",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 8
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/CertAndKeyTestFixtures.java",
         "hashed_secret": "8e98bd491e3da79b478906631c4b4de4284419fa",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 10
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/CertAndKeyTestFixtures.java",
         "hashed_secret": "d88d322997ecae6606b7ddc508a142281b6e4c30",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 12
       }
     ],
     "lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/VerifiableCredentialServiceTestFixtures.java": [
@@ -308,26 +340,31 @@
         "type": "Base64 High Entropy String",
         "filename": "lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/VerifiableCredentialServiceTestFixtures.java",
         "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 12
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/VerifiableCredentialServiceTestFixtures.java",
         "hashed_secret": "095f47d22e20655016ead16e0264f994b0ef5323",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 14
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/VerifiableCredentialServiceTestFixtures.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 16
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/VerifiableCredentialServiceTestFixtures.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 16
       }
     ]
-  }
+  },
+  "generated_at": "2024-10-04T12:03:28Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -69,6 +69,10 @@ Parameters:
     Description: "Mock TXMA SQS Queue"
     Type: String
     Default: "false"
+  LogGroupRetentionInDays:
+    Description: "Retention for all log groups"
+    Type: Number
+    Default: "30"
 
 Conditions:
   IsDeployedFromPipeline: !Equals
@@ -338,7 +342,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PublicUKPassportAPI}-public-AccessLogs
-      RetentionInDays: 365
+      RetentionInDays: !Ref LogGroupRetentionInDays
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   PublicUKPassportAPILogGroupSubscriptionFilter:
@@ -419,7 +423,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateUKPassportAPI}-private-AccessLogs
-      RetentionInDays: 365
+      RetentionInDays: !Ref LogGroupRetentionInDays
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   PrivateUKPassportAPILogGroupSubscriptionFilter:
@@ -545,7 +549,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${CheckPassportFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   CheckPassportFunctionLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -639,7 +643,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${IssueCredentialFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   IssueCredentialFunctionLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -703,7 +707,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${CertExpiryReminderFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   CertExpiryReminderFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
## Proposed changes

### What changed

Ensure log groups are all set to 30 days retention

### Why did it change

To ensure log groups do not have extended retention lengths

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1169](https://govukverify.atlassian.net/browse/LIME-1169)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1169]: https://govukverify.atlassian.net/browse/LIME-1169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ