### PR TITLE
LIME-1208 Add dev perf test script and correctly clean up each ac test

### DIFF
--- a/acceptance-tests/run-dev-perf-test.sh
+++ b/acceptance-tests/run-dev-perf-test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# This uses the same config as the run-local-test.sh
+# Configure it for the pipeline dev environment
+CONF_FILE=test-args.conf
+if [ -f "$CONF_FILE" ]; then
+  export $(grep -v '^#' $CONF_FILE | xargs)
+fi
+
+export BROWSER
+export ENVIRONMENT
+
+if [ "$ENVIRONMENT" != "dev" ]; then
+  echo -e "\033[0;31mWarning Executing Perf test against $ENVIRONMENT\033[0m"
+fi
+
+echo -e "\033[0;31mWarning this is a performance test please close any programs and save work you do not want to loose.\033[0m"
+echo -e "\033[0;31mPlease ensure your computer has 16gb of currently FREE memory\033[0m"
+echo -e "\033[0;31mPlease ensure your computer not being used for this test to valid\033[0m"
+read -p "Press <enter> to continue" I_UNDER_STAND_I_MAY_LOOSE_WORK
+echo -e "\033[1;33mTest Running (Expected run-time 20mins~) \033[0m"
+
+export coreStubUrl=$CORE_STUB_URL
+export coreStubUsername=$CORE_STUB_USERNAME
+export coreStubPassword=$CORE_STUB_PASSWORD
+export orchestratorStubUrl=$ORCHESTRATOR_URL
+export API_GATEWAY_ID_PRIVATE=$API_GATEWAY_ID_PRIVATE
+export API_GATEWAY_ID_PUBLIC=$API_GATEWAY_ID_PUBLIC
+
+###### Run tests
+seq 16 | parallel --progress -j8 -n0 ./gradlew cucumber -P tags=${TAG}
+
+echo -e "\033[1;33mTest Complete\033[0m"

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/UniversalSteps.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/UniversalSteps.java
@@ -2,6 +2,8 @@ package uk.gov.di.ipv.cri.passport.acceptance_tests.pages;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+import org.openqa.selenium.By;
 import org.openqa.selenium.support.PageFactory;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.Driver;
 
@@ -22,11 +24,27 @@ public class UniversalSteps {
         waitForPageToLoad(MAX_WAIT_SEC);
 
         String title = Driver.get().getTitle();
+        if (title == null) {
+            title = "Driver had no page title";
+        }
 
-        boolean match = fuzzy ? title.contains(expTitle) : title.equals(expTitle);
+        final boolean match = fuzzy ? title.contains(expTitle) : title.equals(expTitle);
 
-        LOGGER.info("Page title: " + title);
-        assertTrue(match);
+        LOGGER.info(
+                "{} match - Page title: {}, Expected {}",
+                fuzzy ? "Fuzzy" : "Match",
+                title,
+                expTitle);
+
+        if (!match) {
+            // Log the entire page content if title match fails
+            // Body logged as there are several error pages
+            LOGGER.error(
+                    "Error page content - : {}",
+                    Driver.get().findElement(By.tagName("body")).getText());
+        }
+
+        Assert.assertTrue(match);
     }
 
     public void driverClose() {

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/UniversalStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/UniversalStepDefs.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.passport.acceptance_tests.step_definitions;
 
+import io.cucumber.java.After;
 import io.cucumber.java.en.And;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.pages.UniversalSteps;
 
@@ -33,5 +34,11 @@ public class UniversalStepDefs extends UniversalSteps {
     private static String getProperty(String propertyName) {
         String property = System.getProperty(propertyName);
         return Objects.requireNonNullElse(property, "");
+    }
+
+    @After
+    public void cleanUp() {
+        System.out.println("CleanUp after test");
+        driverClose();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/Driver.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/Driver.java
@@ -94,7 +94,10 @@ public class Driver {
     }
 
     public static void closeDriver() {
-        driverPool.get().quit();
-        driverPool.remove();
+        if (driverPool.get() != null) {
+            driverPool.get().close();
+            driverPool.get().quit();
+            driverPool.remove();
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Add dev perf test script.

Correctly clean up after each ac test.

Add error page logging (from DL ac test)

### Why did it change

To allow a faster build and test iteration with-out involving a full formal perf test.

Ac test where leaving the driver open, leaving lots of browsers open after the test.
This change closes the driver after each test using in built cucumber support.

Error page logging was useful in DL to locate error source.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1208](https://govukverify.atlassian.net/browse/LIME-1208)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1208]: https://govukverify.atlassian.net/browse/LIME-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ