### PR TITLE
LIME-1282 cert expiry permission corrected

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -714,7 +714,8 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt CertExpiryReminderFunction.Arn
-      Principal: scheduler.amazonaws.com
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt CertExpiryReminderEventRule.Arn
 
   CertExpiryReminderEventRule:
     Type: AWS::Events::Rule


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Ensure automated passport CRI certificate expiration alerts are sent to the correct slack channel

### What changed

Updated CertExpiryReminderFunctionPermission in template.yaml

### Why did it change

changes allowed eventbridge rule to trigger certExpiry lambda function.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1282](https://govukverify.atlassian.net/browse/LIME-1282)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1282]: https://govukverify.atlassian.net/browse/LIME-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ