### PR TITLE
LIME-1384 Add Support allow enabling snap-start on all CRI Lambdas.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -244,56 +244,56 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 137
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 140
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 142
+        "line_number": 143
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 146
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 148
+        "line_number": 149
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
         "is_verified": false,
-        "line_number": 165
+        "line_number": 166
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 171
+        "line_number": 172
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 179
+        "line_number": 180
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java": [
@@ -366,5 +366,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-24T13:00:32Z"
+  "generated_at": "2024-11-26T17:34:26Z"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
 		// cri_common_lib dependencies should match the ipv-cri-lib version
 		// Workaround until dependency resolution is fixed.
 		// ---------------------------------------------------------
-		cri_common_lib_version             : "3.0.5",
+		cri_common_lib_version             : "3.7.0",
 
 		// AWS SDK
 		aws_sdk_version                    : "2.28.21",

--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -42,7 +42,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CheckPassportFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CheckPassportFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -81,7 +81,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-SessionFunction/invocations
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-SessionFunction:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -123,7 +123,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AuthorizationFunction/invocations
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AuthorizationFunction:live/invocations
         passthroughBehavior: "when_no_match"
 
 components:

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -61,7 +61,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AccessTokenFunction/invocations
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AccessTokenFunction:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -111,7 +111,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueCredentialFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1,5 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Transform: AWS::Serverless-2016-10-31
+Transform: ["AWS::Serverless-2016-10-31", 'AWS::LanguageExtensions']
+
 Description: Digital Identity Passport Credential Issuer API
 Metadata:
   cfn-lint:
@@ -195,6 +196,7 @@ Mappings:
       integration: "6"
       production: "6"
 
+  # CANNOT be 1 with SnapStart
   ProvisionedConcurrency:
     Environment:
       dev: 0
@@ -202,6 +204,15 @@ Mappings:
       staging: 1
       integration: 1
       production: 1
+
+  # CANNOT be used with ProvisionedConcurrency
+  SnapStartMapping:
+    Environment:
+      dev: None
+      build: None
+      staging: None
+      integration: None
+      production: None
 
   # VC Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
   JwtTtlUnitMapping:
@@ -477,6 +488,9 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-checkpassport"
           ENVIRONMENT: !Ref Environment
           DEV_ENVIRONMENT_ONLY_ENHANCED_DEBUG: !FindInMap [ DevEnvironmentOnlyEnhancedDebugMapping, Environment, !Ref Environment ]
+      AutoPublishAlias: live
+      SnapStart:
+        ApplyOn: !FindInMap [ SnapStartMapping, Environment, !Ref Environment ]
       Policies:
         - DynamoDBWritePolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
@@ -538,7 +552,6 @@ Resources:
                 - CreateMockTxmaResources
                 - !GetAtt MockAuditEventQueueEncryptionKey.Arn
                 - Fn::ImportValue: AuditEventQueueEncryptionKeyArn
-      AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
@@ -563,7 +576,14 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !GetAtt CheckPassportFunction.Arn
+      FunctionName: !GetAtt CertExpiryReminderFunction.Arn
+      Principal: apigateway.amazonaws.com
+
+  CheckPassportFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref CheckPassportFunction.Alias
       Principal: apigateway.amazonaws.com
 
 ####################################################################
@@ -589,6 +609,9 @@ Resources:
           ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED: !FindInMap [ FeatureFlagMapping, !Ref Environment, VcExpiryRemoved ]
           ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID: !FindInMap [ FeatureFlagMapping, !Ref Environment, VcContainsUniqueIdMapping ]
           INCLUDE_VC_KID: !FindInMap [ FeatureFlagMapping, !Ref Environment, IncludeKidInVc ]
+      AutoPublishAlias: live
+      SnapStart:
+        ApplyOn: !FindInMap [ SnapStartMapping, Environment, !Ref Environment ]
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
@@ -632,7 +655,6 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiableCredentialKmsSigningKeyId"
-      AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
@@ -660,6 +682,13 @@ Resources:
       FunctionName: !GetAtt IssueCredentialFunction.Arn
       Principal: apigateway.amazonaws.com
 
+  IssueCredentialFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref IssueCredentialFunction.Alias
+      Principal: apigateway.amazonaws.com
+
   ####################################################################
   #                                                                  #
   # Cert expiry reminder function                                    #
@@ -675,6 +704,9 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-CertExpiryReminder"
+      AutoPublishAlias: live
+      SnapStart:
+        ApplyOn: !FindInMap [ SnapStartMapping, Environment, !Ref Environment ]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -713,7 +745,7 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !GetAtt CertExpiryReminderFunction.Arn
+      FunctionName: !Ref CertExpiryReminderFunction.Alias
       Principal: events.amazonaws.com
       SourceArn: !GetAtt CertExpiryReminderEventRule.Arn
 
@@ -724,7 +756,7 @@ Resources:
       ScheduleExpression: "cron(0 12 ? * MON-FRI *)"
       State: ENABLED
       Targets:
-        - Arn: !GetAtt CertExpiryReminderFunction.Arn
+        - Arn: !Ref CertExpiryReminderFunction.Alias
           Id: scheduled-Cert-Expiry-event
           RetryPolicy:
             MaximumRetryAttempts: 0

--- a/lambdas/certexpiryreminder/build.gradle
+++ b/lambdas/certexpiryreminder/build.gradle
@@ -12,6 +12,7 @@ configurations.all {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+	exclude group:"software.amazon.awssdk", module: "url-connection-client"
 }
 
 dependencies {

--- a/lambdas/checkpassport/build.gradle
+++ b/lambdas/checkpassport/build.gradle
@@ -13,6 +13,7 @@ configurations.all {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+	exclude group:"software.amazon.awssdk", module: "url-connection-client"
 }
 
 dependencies {

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
@@ -130,6 +130,11 @@ public class CheckPassportHandler
 
         this.thirdPartyAPIServiceFactory = new ThirdPartyAPIServiceFactory(serviceFactory);
 
+        // Prime DynamoDB Client
+        SessionItem primedSessionItem = sessionService.getSession("-1");
+        String loggedValue = String.valueOf(primedSessionItem);
+        LOGGER.info("DynamoDB primed - {}", loggedValue);
+
         // Runtime/SnapStart function init duration
         functionInitMetricLatchedValue =
                 System.currentTimeMillis() - FUNCTION_INIT_START_TIME_MILLISECONDS;

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -8,6 +8,13 @@ plugins {
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.7.1'
 }
 
+configurations.all {
+	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
+	exclude group:"software.amazon.awssdk", module: "apache-client"
+	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+	exclude group:"software.amazon.awssdk", module: "url-connection-client"
+}
+
 dependencies {
 	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"), project(":lib"),
 			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/handler/IssueCredentialHandler.java
@@ -26,6 +26,7 @@ import uk.gov.di.ipv.cri.common.library.exception.SessionExpiredException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionNotFoundException;
 import uk.gov.di.ipv.cri.common.library.exception.SqsException;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.PersonIdentityService;
@@ -119,6 +120,11 @@ public class IssueCredentialHandler
         this.documentCheckResultStore = serviceFactory.getDocumentCheckResultStore();
 
         this.verifiableCredentialService = verifiableCredentialService;
+
+        // Prime DynamoDB Client
+        SessionItem primedSessionItem = sessionService.getSession("-1");
+        String loggedValue = String.valueOf(primedSessionItem);
+        LOGGER.info("DynamoDB primed - {}", loggedValue);
 
         // Runtime/SnapStart function init duration
         functionInitMetricLatchedValue =

--- a/lib-dvad/build.gradle
+++ b/lib-dvad/build.gradle
@@ -13,6 +13,7 @@ configurations.all {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+	exclude group:"software.amazon.awssdk", module: "url-connection-client"
 }
 
 dependencies {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -13,6 +13,7 @@ configurations.all {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+	exclude group:"software.amazon.awssdk", module: "url-connection-client"
 }
 
 dependencies {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

	- SnapStartMapping added to enable snap-start role out only to specific environments to allow more testing prior to production role out.
	- Moves all Passport lambda invocation paths and permissions to use the live alias
	- - Cert Reminder event rule also updated
	- Excludes unneeded url-connection-client aws dependancy in build.gradle files.

	- Primes the DynamoDB Client during snap start.
	- - This enables snap start to capture some more classes.
	- - And avoid the DynamoDB client being initialised during the first request saving some time

### Why did it change

To enable snap-start on all Passport CRI internal lambdas.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1384](https://govukverify.atlassian.net/browse/LIME-1384)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1384]: https://govukverify.atlassian.net/browse/LIME-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ