### PR TITLE
LIME-1384 Disable ProvisionedConcurrency in build add AutoPublishAliasAllProperties

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -200,7 +200,7 @@ Mappings:
   ProvisionedConcurrency:
     Environment:
       dev: 0
-      build: 1
+      build: 0
       staging: 1
       integration: 1
       production: 1
@@ -489,6 +489,7 @@ Resources:
           ENVIRONMENT: !Ref Environment
           DEV_ENVIRONMENT_ONLY_ENHANCED_DEBUG: !FindInMap [ DevEnvironmentOnlyEnhancedDebugMapping, Environment, !Ref Environment ]
       AutoPublishAlias: live
+      AutoPublishAliasAllProperties: true
       SnapStart:
         ApplyOn: !FindInMap [ SnapStartMapping, Environment, !Ref Environment ]
       Policies:
@@ -610,6 +611,7 @@ Resources:
           ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID: !FindInMap [ FeatureFlagMapping, !Ref Environment, VcContainsUniqueIdMapping ]
           INCLUDE_VC_KID: !FindInMap [ FeatureFlagMapping, !Ref Environment, IncludeKidInVc ]
       AutoPublishAlias: live
+      AutoPublishAliasAllProperties: true
       SnapStart:
         ApplyOn: !FindInMap [ SnapStartMapping, Environment, !Ref Environment ]
       Policies:
@@ -705,6 +707,7 @@ Resources:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-CertExpiryReminder"
       AutoPublishAlias: live
+      AutoPublishAliasAllProperties: true
       SnapStart:
         ApplyOn: !FindInMap [ SnapStartMapping, Environment, !Ref Environment ]
       Policies:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Disable ProvisionedConcurrency in build add AutoPublishAliasAllProperties to help ensure lambda versions are published

### Why did it change

ProvisionedConcurrency was not enable in the CRI until recently.
This reverts that change for just the build environment to allow a performance test as the CRI was configured then.


### Issue tracking

- [LIME-1384](https://govukverify.atlassian.net/browse/LIME-1384)
- [DCP-4141](https://govukverify.atlassian.net/browse/DCP-4141)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1384]: https://govukverify.atlassian.net/browse/LIME-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DCP-4141]: https://govukverify.atlassian.net/browse/DCP-4141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ