### PR TITLE
LIME-1436 Re-enable ProvisionedConcurrency in build

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -200,7 +200,7 @@ Mappings:
   ProvisionedConcurrency:
     Environment:
       dev: 0
-      build: 0
+      build: 1
       staging: 1
       integration: 1
       production: 1


### PR DESCRIPTION
## Proposed changes

### What changed

Re-enable ProvisionedConcurrency in build

### Why did it change

To enable a performance test with ProvisionedConcurrency

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1436](https://govukverify.atlassian.net/browse/LIME-1436)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1436]: https://govukverify.atlassian.net/browse/LIME-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ