### PR TITLE
LIME-1437 Enable snap-start for Passport CRI (dev-staging)

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -200,17 +200,17 @@ Mappings:
   ProvisionedConcurrency:
     Environment:
       dev: 0
-      build: 1
-      staging: 1
+      build: 0
+      staging: 0
       integration: 1
       production: 1
 
   # CANNOT be used with ProvisionedConcurrency
   SnapStartMapping:
     Environment:
-      dev: None
-      build: None
-      staging: None
+      dev: PublishedVersions
+      build: PublishedVersions
+      staging: PublishedVersions
       integration: None
       production: None
 


### PR DESCRIPTION
## Proposed changes

### What changed

Enable snap-start for Passport CRI (dev-staging)

### Why did it change

To test snap-start prior to production roll out

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1437](https://govukverify.atlassian.net/browse/LIME-1437)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1437]: https://govukverify.atlassian.net/browse/LIME-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ