### PR TITLE
LIME-1456 Bump aws_sdk_version from 2.28.21 to 2.29.27

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 		cri_common_lib_version             : "1.5.4",
 
 		// CRI_LIB aws
-		aws_sdk_version                    : "2.28.21",
+		aws_sdk_version                    : "2.29.27",
 		aws_lambda_events_version          : "3.11.0",
 		aws_embedded_metrics_version       : "1.0.6",
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
 		cri_common_lib_version             : "3.7.0",
 
 		// AWS SDK
-		aws_sdk_version                    : "2.28.21",
+		aws_sdk_version                    : "2.29.27",
 		aws_lambda_events_version          : "3.14.0",
 
 		// Nimbus Oauth


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Align aws sdk version with other CRIs

### What changed

Bumped aws_sdk_version from 2.28.21 to 2.29.27

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1456](https://govukverify.atlassian.net/browse/LIME-1456)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1456]: https://govukverify.atlassian.net/browse/LIME-1456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ