### PR TITLE
Ips 1240 traffic test

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - IPS-1240-traffic-test
   workflow_dispatch: # deploy manually
 
 jobs:
@@ -21,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -46,6 +48,41 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.9.0'
+
+      - name: Build, push traffic test image to ECR
+        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # pin@1.3.0
+        with:
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_DEV }}
+          role-to-assume-arn: ${{ secrets.AWS_DEV_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_TRAFFIC_TEST_DEV }}
+          working-directory: acceptance-tests
+          dockerfile: Dockerfile-traffictest
+          build-and-push-image-only: "true"
+          push-latest-tag: true
+
+      - name: reset to working directory
+        run: cd ${GITHUB_WORKSPACE}
+
+      - name: Build, tag, and push testing images to Amazon ECR
+        env:
+          CONTAINER_SIGN_KMS_KEY_DEV: ${{ secrets.CONTAINER_SIGN_KMS_KEY_DEV }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY_DEV: ${{ secrets.ECR_REPOSITORY_DEV }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG acceptance-tests
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
+          cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY_DEV} $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
+
+      - name: reset to working directory
+        run: cd ${GITHUB_WORKSPACE}
+
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml --lint
 
@@ -60,33 +97,3 @@ jobs:
           artifact-bucket-name: "${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.DEV_SIGNING_PROFILE_NAME }}"
           working-directory: ./out
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.9.0'
-
-      - name: Build, tag, and push testing images to Amazon ECR
-        env:
-          CONTAINER_SIGN_KMS_KEY_DEV: ${{ secrets.CONTAINER_SIGN_KMS_KEY_DEV }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY_DEV: ${{ secrets.ECR_REPOSITORY_DEV }}
-          IMAGE_TAG: latest
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG acceptance-tests
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
-          cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY_DEV} $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
-
-
-      - name: Build, push traffic test image to ECR
-        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # pin@1.3.0
-        with:
-          artifact-bucket-name: ""
-          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_DEV }}
-          role-to-assume-arn: ${{ secrets.AWS_DEV_ROLE_ARN }}
-          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_TRAFFIC_TEST_DEV }}
-          working-directory: acceptance-tests
-          dockerfile: Dockerfile-traffictest
-          build-and-push-image-only: "true"
-          push-latest-tag: true

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - IPS-1240-traffic-test
   workflow_dispatch: # deploy manually
 
 jobs:

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -42,6 +42,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEV_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml --lint
 
@@ -56,10 +60,6 @@ jobs:
           artifact-bucket-name: "${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.DEV_SIGNING_PROFILE_NAME }}"
           working-directory: ./out
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
@@ -77,3 +77,16 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
           cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY_DEV} $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
+
+
+      - name: Build, push traffic test image to ECR
+        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # pin@1.3.0
+        with:
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_DEV }}
+          role-to-assume-arn: ${{ secrets.AWS_DEV_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_TRAFFIC_TEST_DEV }}
+          working-directory: acceptance-tests
+          dockerfile: Dockerfile-traffictest
+          build-and-push-image-only: "true"
+          push-latest-tag: true

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -52,6 +52,13 @@ jobs:
           mkdir build
           sam build -t infrastructure/lambda/template.yaml -b out
 
+      - name: Deploy SAM app
+        uses: govuk-one-login/devplatform-upload-action@v3.9
+        with:
+          artifact-bucket-name: "${{ secrets.ARTIFACT_BUCKET_NAME }}"
+          signing-profile-name: "${{ secrets.SIGNING_PROFILE_NAME }}"
+          working-directory: ./out
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
@@ -76,10 +83,14 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
           cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
 
-
-      - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.9
+      - name: Build, push traffic test image to ECR
+        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # pin@1.3.0
         with:
-          artifact-bucket-name: "${{ secrets.ARTIFACT_BUCKET_NAME }}"
-          signing-profile-name: "${{ secrets.SIGNING_PROFILE_NAME }}"
-          working-directory: ./out
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_TRAFFIC_TEST_BUILD }}
+          working-directory: acceptance-tests
+          dockerfile: Dockerfile-traffictest
+          build-and-push-image-only: "true"
+          push-latest-tag: true

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: SAM build
         run: |
-          mkdir build
+          mkdir out
           sam build -t infrastructure/lambda/template.yaml -b out
 
       - name: Deploy SAM app

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -44,21 +44,6 @@ jobs:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml --lint
-
-      - name: SAM build
-        run: |
-          mkdir build
-          sam build -t infrastructure/lambda/template.yaml -b out
-
-      - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.9
-        with:
-          artifact-bucket-name: "${{ secrets.ARTIFACT_BUCKET_NAME }}"
-          signing-profile-name: "${{ secrets.SIGNING_PROFILE_NAME }}"
-          working-directory: ./out
-
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
@@ -67,6 +52,21 @@ jobs:
         uses: sigstore/cosign-installer@main
         with:
           cosign-release: 'v1.9.0'
+
+      - name: Build, push traffic test image to ECR
+        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # pin@1.3.0
+        with:
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_TRAFFIC_TEST_BUILD }}
+          working-directory: acceptance-tests
+          dockerfile: Dockerfile-traffictest
+          build-and-push-image-only: "true"
+          push-latest-tag: true
+
+      - name: reset to working directory
+        run: cd ${GITHUB_WORKSPACE}
 
       - name: Build, tag, and push testing images to Amazon ECR
         env:
@@ -83,14 +83,20 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
           cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
 
-      - name: Build, push traffic test image to ECR
-        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # pin@1.3.0
+      - name: reset to working directory
+        run: cd ${GITHUB_WORKSPACE}
+
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml --lint
+
+      - name: SAM build
+        run: |
+          mkdir build
+          sam build -t infrastructure/lambda/template.yaml -b out
+
+      - name: Deploy SAM app
+        uses: govuk-one-login/devplatform-upload-action@v3.9
         with:
-          artifact-bucket-name: ""
-          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
-          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
-          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_TRAFFIC_TEST_BUILD }}
-          working-directory: acceptance-tests
-          dockerfile: Dockerfile-traffictest
-          build-and-push-image-only: "true"
-          push-latest-tag: true
+          artifact-bucket-name: "${{ secrets.ARTIFACT_BUCKET_NAME }}"
+          signing-profile-name: "${{ secrets.SIGNING_PROFILE_NAME }}"
+          working-directory: ./out

--- a/acceptance-tests/Dockerfile-traffictest
+++ b/acceptance-tests/Dockerfile-traffictest
@@ -1,0 +1,25 @@
+FROM gradle:8.4-jdk17-jammy
+# The following will allow you to test building the amd64 image on an arm64 mac
+# DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build --tag 'passport-ac-test-image' .
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
+
+RUN apt-get update
+RUN apt-get install -y libglib2.0-0
+RUN apt-get install -y libnss3
+RUN apt-get install -y libglu1
+RUN apt-get install -y libxcb1
+RUN apt-get install -y libappindicator1 fonts-liberation
+RUN apt-get -y install dbus-x11 xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cyrillic xfonts-scalable
+RUN apt-get -y install libxss1 lsb-release xdg-utils
+RUN apt-get -y install jq
+
+# Chrome not available for arm64 linux currently and we want to use chrome not chromium
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg --configure -a
+RUN dpkg -i --force-depends google-chrome-stable_current_amd64.deb
+RUN apt-get install -fy
+
+COPY . .
+RUN mv traffic-tests/run-tests.sh /run-tests.sh
+ENTRYPOINT ["/run-tests.sh"]

--- a/acceptance-tests/traffic-tests/run-tests.sh
+++ b/acceptance-tests/traffic-tests/run-tests.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e
+
+export BROWSER="${BROWSER:-chrome-headless}"
+export NO_CHROME_SANDBOX=true
+
+
+# Added to accommodate ssm stack
+if [[ -z "${CFN_StackName}" ]]; then
+  if [[ -z "${SAM_STACK_NAME}" ]]; then
+    export STACK_NAME="local"
+  else
+    export STACK_NAME="${SAM_STACK_NAME}"
+  fi
+else
+  export STACK_NAME="${CFN_StackName}"
+fi
+
+# Added to accommodate ssm stack
+if [[ -z "${ENVIRONMENT}" ]]; then
+  if [[ -z "${TEST_ENVIRONMENT}" ]]; then
+    export ENVIRONMENT="build"
+  else
+    export ENVIRONMENT="${TEST_ENVIRONMENT}"
+  fi
+else
+  export ENVIRONMENT="${ENVIRONMENT}"
+fi
+
+echo "ENVIRONMENT ${ENVIRONMENT}"
+echo "STACK_NAME ${STACK_NAME}"
+
+if [ "${STACK_NAME}" != "local" ]; then
+  export JOURNEY_TAG=$(aws ssm get-parameter --name "/tests/${STACK_NAME}/TestTag" | jq -r ".Parameter.Value")
+
+  PARAMETERS_NAMES=(coreStubPassword coreStubUrl coreStubUsername passportCriUrl apiBaseUrl orchestratorStubUrl)
+  tLen=${#PARAMETERS_NAMES[@]}
+   for (( i=0; i<${tLen}; i++ ));
+  do
+    echo "/tests/$STACK_NAME/${PARAMETERS_NAMES[$i]}"
+    PARAMETER=$(aws ssm get-parameter --name "/tests/$STACK_NAME/${PARAMETERS_NAMES[$i]}" --region eu-west-2)
+    VALUE=$(echo "$PARAMETER" | jq '.Parameter.Value')
+    NAME=$(echo "$PARAMETER" | jq '.Parameter.Name' | cut -d "/" -f4 | sed 's/.$//')
+
+    eval $(echo "export ${NAME}=${VALUE}")
+  done
+else
+  export JOURNEY_TAG="${TEST_TAG}"
+fi
+
+pushd /home/gradle
+gradle cucumber -P tags=${JOURNEY_TAG}
+popd


### PR DESCRIPTION
## Proposed changes

### What changed

Traffic tests have been added as they are needed for canary work.
Existing acceptance test has been used for this and moved to a separate ecr for traffic tests.
Further work will focus on passing more traffic through the deployment stage, currently this traffic test invokes each lambda only once. 

### Why did it change

Canary deployments means there are two versions of an application. To check backwards compatibility, traffic tests can be used in lower environments. This prevents backwards incompatible versions reaching production and issues only being discovered in production.

### Issue tracking

- [IPS-1240](https://govukverify.atlassian.net/browse/IPS-1240)

### Other considerations

GH secrets added, these are the TestRunnerImageEcrRepositoryName values taken from traffic test repo:
ECR_REPOSITORY_TRAFFIC_TEST_DEV
ECR_REPOSITORY_TRAFFIC_TEST_BUILD

Test dev workflow run with traffic test image deployed before before service: https://github.com/govuk-one-login/ipv-cri-uk-passport-api/actions/runs/12201425625/job/34039798945

[IPS-1240]: https://govukverify.atlassian.net/browse/IPS-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ