### PR TITLE
LIME-1437 Remove DynamoDB Client initialisation from snap-start snap-shot

### DIFF
--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/handler/CheckPassportHandler.java
@@ -130,11 +130,6 @@ public class CheckPassportHandler
 
         this.thirdPartyAPIServiceFactory = new ThirdPartyAPIServiceFactory(serviceFactory);
 
-        // Prime DynamoDB Client
-        SessionItem primedSessionItem = sessionService.getSession("-1");
-        String loggedValue = String.valueOf(primedSessionItem);
-        LOGGER.info("DynamoDB primed - {}", loggedValue);
-
         // Runtime/SnapStart function init duration
         functionInitMetricLatchedValue =
                 System.currentTimeMillis() - FUNCTION_INIT_START_TIME_MILLISECONDS;


### PR DESCRIPTION
## Proposed changes

### What changed

Remove DynamoDB Client initialisation from snap-start snap-shot

### Why did it change

Disabled as it will be caching connection state that will only be valid for a short period after the snap-shot.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1437](https://govukverify.atlassian.net/browse/LIME-1437)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1437]: https://govukverify.atlassian.net/browse/LIME-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ