### PR TITLE
LIME-1521 Remove ProvisionedConcurrency from integration and production

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -209,8 +209,8 @@ Mappings:
       dev: 0
       build: 0
       staging: 0
-      integration: 1
-      production: 1
+      integration: 0
+      production: 0
 
   # CANNOT be used with ProvisionedConcurrency
   SnapStartMapping:


### PR DESCRIPTION
## Proposed changes

### What changed

Remove ProvisionedConcurrency from integration and production

### Why did it change

To allow switching to a snap-start configuration

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1521](https://govukverify.atlassian.net/browse/LIME-1521)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1521]: https://govukverify.atlassian.net/browse/LIME-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ