### PR TITLE
LIME-1521 Enable SnapStart in integration and production

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -218,8 +218,8 @@ Mappings:
       dev: PublishedVersions
       build: PublishedVersions
       staging: PublishedVersions
-      integration: None
-      production: None
+      integration: PublishedVersions
+      production: PublishedVersions
 
   # VC Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
   JwtTtlUnitMapping:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Configured PublishedVersions in the SnapStartMapping for integration and production
NOTE - this PR https://github.com/govuk-one-login/ipv-cri-uk-passport-api/pull/215 needs merged first and successfully deployed to allow switching from a ProvisionedConcurrency configuration to SnapStart

### Why did it change

To complete the switch to all lambdas having snap-start enabled.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1521](https://govukverify.atlassian.net/browse/LIME-1521)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1521]: https://govukverify.atlassian.net/browse/LIME-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ