### PR TITLE
Lime 1591 - Amended tests to account for updated pageTitle and unknown error test uncommented

### DIFF
--- a/acceptance-tests/src/test/resources/features/passport/English/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/English/Passport.feature
@@ -217,12 +217,11 @@ Feature: Passport Test
       | PassportSubjectHappyKenneth | 18     | 1              |
       | PassportSubjectHappyKenneth | 18     | 2              |
 
-    #LIME-1578
-#  @build @staging @integration @stub @uat
-#  Scenario: Check the Unrecoverable error/ Unknown error in Passport CRI
-#    Given I delete the service_session cookie to get the unexpected error
-#    When I check the page title is Sorry, there is a problem – GOV.UK One Login
-#    And The test is complete and I close the driver
+  @build @staging @integration @stub @uat
+  Scenario: Check the Unrecoverable error/ Unknown error in Passport CRI
+    Given I delete the service_session cookie to get the unexpected error
+    When I check the page title is Sorry, there is a problem – GOV.UK One Login
+    And The test is complete and I close the driver
 
   @build @Language-regression
   Scenario Outline: Language Title validation

--- a/acceptance-tests/src/test/resources/features/passport/English/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/English/Passport.feature
@@ -5,7 +5,7 @@ Feature: Passport Test
     Given I navigate to the IPV Core Stub
     And I click the passport CRI for the testEnvironment
     And I search for passport user number 5 in the Experian table
-    Then I check the page title is Enter your details exactly as they appear on your UK passport – Prove your identity – GOV.UK
+    Then I check the page title is Enter your details exactly as they appear on your UK passport – GOV.UK One Login
     And I assert the url path contains details
     And I set the document checking route
 
@@ -221,13 +221,13 @@ Feature: Passport Test
 #  @build @staging @integration @stub @uat
 #  Scenario: Check the Unrecoverable error/ Unknown error in Passport CRI
 #    Given I delete the service_session cookie to get the unexpected error
-#    When I check the page title is Sorry, there is a problem – Prove your identity – GOV.UK
+#    When I check the page title is Sorry, there is a problem – GOV.UK One Login
 #    And The test is complete and I close the driver
 
   @build @Language-regression
   Scenario Outline: Language Title validation
     Given User clicks on language toggle and switches to Welsh
-    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU – Profi pwy ydych chi – GOV.UK
+    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU – GOV.UK One Login
     Then User enters data as a <PassportSubject>
     When User clicks on continue
     Then I navigate to the passport verifiable issuer to check for a Valid response
@@ -242,7 +242,7 @@ Feature: Passport Test
 
   @build @stub
   Scenario Outline: Error tab title validation
-    And I check the page title is Enter your details exactly as they appear on your UK passport – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK passport – GOV.UK One Login
     Then User enters data as a <PassportSubject>
     And User re-enters passport number as <InvalidPassportNumber>
     And User re-enters last name as <InvalidLastName>
@@ -254,7 +254,7 @@ Feature: Passport Test
     And User re-enters valid to month as <InvalidValidToMonth>
     And User re-enters valid to year as <InvalidValidToYear>
     And User clicks on continue
-    Then I check the page title is Error: Enter your details exactly as they appear on your UK passport – Prove your identity – GOV.UK
+    Then I check the page title is Error: Enter your details exactly as they appear on your UK passport – GOV.UK One Login
     And The test is complete and I close the driver
     Examples:
       | PassportSubject             | InvalidPassportNumber | InvalidLastName | InvalidFirstName | InvalidBirthDay | InvalidBirthMonth | InvalidBirthYear | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear | Scenario                              |

--- a/acceptance-tests/src/test/resources/features/passport/English/PassportFullJourneyfeature.feature
+++ b/acceptance-tests/src/test/resources/features/passport/English/PassportFullJourneyfeature.feature
@@ -109,7 +109,7 @@ Feature: E2E
     And the user chooses their address 8 HADLEY ROAD, BATH, BA2 5AA from dropdown and click `Choose address`
     And the user enters the date 2014 they moved into their current address
     And the user clicks `I confirm my details are correct`
-    Then I check the page title is We need to check your details – Prove your identity – GOV.UK
+    Then I check the page title is We need to check your details – GOV.UK One Login
     When I check Continue button is enabled and click on the Continue button
     And the user clicks `Answer security questions`
     And kenneth answers the first question correctly

--- a/acceptance-tests/src/test/resources/features/passport/Welsh/WelshLangPassport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/Welsh/WelshLangPassport.feature
@@ -26,7 +26,7 @@ Feature: Passport Language Test
 
   @Language-regression
   Scenario:User Selects landed in the passport page and Validate the title and sentences
-    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU – Profi pwy ydych chi – GOV.UK
+    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU – GOV.UK One Login
     And I see the heading Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU
     And I see We will check your details as Byddwn yn gwirio eich manylion gydar DVLA i sicrhau nad yw eich pasbort yrru wedi cael ei chanslo na'i hadrodd fel un sydd ar goll neu wedi ei dwyn.
     And I see sentence Os nad oes gennych basbort y DU neu os na allwch gofio’ch manylion, gallwch brofi pwy ydych chi mewn ffordd arall yn lle hynny.
@@ -108,7 +108,7 @@ Feature: Passport Language Test
 
   @Language-regression
   Scenario:User Selects Passport and landed in passport with page and Page title and sub-text
-    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU – Profi pwy ydych chi – GOV.UK
+    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU – GOV.UK One Login
     Then I see the heading Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU
     And I see sentence Os nad oes gennych basbort y DU neu os na allwch gofio’ch manylion, gallwch brofi pwy ydych chi mewn ffordd arall yn lle hynny.
     And The test is complete and I close the driver
@@ -203,10 +203,10 @@ Feature: Passport Language Test
 
   @Language-regression
   Scenario Outline: Error tab title validation
-    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU – Profi pwy ydych chi – GOV.UK
+    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU – GOV.UK One Login
     Then User enters data as a <PassportSubject>
     And User clicks on continue
-    Then I check the page title is Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU – Profi pwy ydych chi – GOV.UK
+    Then I check the page title is Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU – GOV.UK One Login
     And The test is complete and I close the driver
     Examples:
       |PassportSubject |
@@ -215,7 +215,7 @@ Feature: Passport Language Test
   @Language-regression
   Scenario Outline: Language Title validation
     Given User clicks language toggle and switches to English
-    Then I check the page title is Enter your details exactly as they appear on your UK passport – Prove your identity – GOV.UK
+    Then I check the page title is Enter your details exactly as they appear on your UK passport – GOV.UK One Login
     Then User enters data as a <PassportSubject>
     When User clicks on continue
     Then I navigate to the passport verifiable issuer to check for a Valid response


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

1591 - serviceName amended to remove _"... - Prove your identity" from page tab titles in DL FE. BE tests updated to reflect this and the adding of 'One Login' to the pageTitle suffix brought in by the Common Express update.

1578 - In addition, one test was uncommented in relation to a separate ticket (1578). This _'Check the Unrecoverable error/ Unknown error in Passport CRI'_ test was commented out whilst a fix was sort for it failing. This has now been resolved as a result of the update to common express 10.3.0 so the test can be added back in. 

### Why did it change

To keep this service in line with other services of the programme and fix failing tests as a result of the Common Express update beyond 10.1.x.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1591](https://govukverify.atlassian.net/browse/LIME-1591)
- [LIME-1578](https://govukverify.atlassian.net/browse/LIME-1578)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1508]: https://govukverify.atlassian.net/browse/LIME-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIME-1591]: https://govukverify.atlassian.net/browse/LIME-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ