### PR TITLE
BAU googleJavaFormat updated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ dependencies {
 spotless {
 	java {
 		target "**/src/**/*.java"
-		googleJavaFormat("1.13.0").aosp()
+		googleJavaFormat("1.25.2").aosp()
 		importOrder "", "javax", "java", "\\#"
 		endWithNewline()
 		sourceCompatibility = "${javaCompatibility.source}"


### PR DESCRIPTION
## Proposed changes

### What changed

googleJavaFormat updated to 1.25.2

### Why did it change

Acceptance tests failing
```
> Task :cucumber FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/home/gradle/build.gradle' line: 119

* What went wrong:
Execution failed for task ':cucumber'.
> Process 'command '/opt/java/openjdk/bin/java'' finished with non-zero exit value 1
```

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXXX)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
