### PR TITLE
LIME-1592 Specified well-known/jwks endpoint for passport pilot

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -244,56 +244,56 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 146
+        "line_number": 147
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 150
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 152
+        "line_number": 153
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 155
+        "line_number": 156
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 158
+        "line_number": 159
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
         "is_verified": false,
-        "line_number": 178
+        "line_number": 179
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 184
+        "line_number": 185
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 192
+        "line_number": 193
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java": [
@@ -366,5 +366,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-20T21:26:35Z"
+  "generated_at": "2025-04-02T09:00:10Z"
 }

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -70,7 +70,7 @@ paths:
         type: "aws_proxy"
 
   /credential/issue:
-    summary: Resource for the Fraud API
+    summary: Resource for the Passport API
     description: >-
       This API is expected to be called by the IPV core backend directly as the
       final part of the OpenId/Oauth Flow
@@ -118,6 +118,143 @@ paths:
         passthroughBehavior: "when_no_match"
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws_proxy"
+
+  /.well-known/jwks.json:
+    get:
+      operationId: getWellKnownJwksJson
+      summary: Retrieve the encryption public keys for JWTs issued by `POST /userinfo`.
+      description: >-
+        Return the current valid public keys used to encrypt JWTs issued by the service as a JSON Web Key Set
+      tags:
+        - Backend - Passport CRI specific
+      responses:
+        "200":
+          description: >-
+            OK - key ring returned
+          headers:
+            Cache-Control:
+              schema:
+                type: "string"
+            Content-Type:
+              schema:
+                type: "string"
+            Strict-Transport-Security:
+              schema:
+                type: "string"
+            X-Content-Type-Options:
+              schema:
+                type: "string"
+            X-Frame-Options:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JWKSFile"
+        "400":
+          description: 400 response
+          headers:
+            Cache-Control:
+              schema:
+                type: "string"
+            Content-Type:
+              schema:
+                type: "string"
+            Strict-Transport-Security:
+              schema:
+                type: "string"
+            X-Content-Type-Options:
+              schema:
+                type: "string"
+            X-Frame-Options:
+              schema:
+                type: "string"
+        "500":
+          description: Internal Server Error
+          headers:
+            Cache-Control:
+              schema:
+                type: "string"
+            Content-Type:
+              schema:
+                type: "string"
+            Strict-Transport-Security:
+              schema:
+                type: "string"
+            X-Content-Type-Options:
+              schema:
+                type: "string"
+            X-Frame-Options:
+              schema:
+                type: "string"
+      x-amazon-apigateway-request-validator: "both"
+      x-amazon-apigateway-integration:
+        httpMethod: "GET"
+        credentials:
+          Fn::GetAtt: [ "JWKSBucketRole", "Arn" ]
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/passport-${Environment}-key-rotation-bucket/jwks.json"
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws"
+
+components:
+  schemas:
+    JWKSFile:
+      type: object
+      required:
+        - keys
+      additionalProperties: true
+      properties:
+        keys:
+          type: array
+          description: >-
+            The value of the `keys` parameter is an array of JWK values. By default, the order of the JWK
+            values within the array does not imply an order of preference among them, although applications of
+            JWK Sets can choose to assign a meaning to the order for their purposes, if desired.
+          items:
+            type: object
+            additionalProperties: true
+            description: >-
+              A JSON Web Key (JWK) as defined by [RFC7517](https://www.rfc-editor.org/rfc/rfc7517)
+            properties:
+              kty:
+                type: string
+                description: >-
+                  The `kty` (key type) parameter identifies the cryptographic algorithm family used with the
+                  key, such as `RSA or `EC`
+              use:
+                type: string
+                enum:
+                  - sig
+                  - enc
+                description: >-
+                  The "use" (public key use) parameter identifies the intended use of the public key.  The
+                  "use" parameter is employed to indicate whether a public key is used for encrypting data or
+                  verifying the signature on data. Valid values are `sig` (signature) and `enc` (encryption).
+              alg:
+                type: string
+                description: >-
+                  The `alg` (algorithm) parameter identifies the algorithm intended for use with the key.
+              kid:
+                type: string
+                description: >-
+                  The `kid` (key ID) parameter is used to match a specific key. This is used, for instance,
+                  to choose among a set of keys within a JWK Set during key rollover.  The structure of the
+                  `kid` value is unspecified.
+              e:
+                type: string
+                description: >-
+                  public exponent
+              n:
+                type: string
+                description: >-
+                  public modulus
+            required:
+              - kty
 
 x-amazon-apigateway-request-validators:
   Validate both:

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -122,9 +122,9 @@ paths:
   /.well-known/jwks.json:
     get:
       operationId: getWellKnownJwksJson
-      summary: Retrieve the encryption public keys for JWTs issued by `POST /userinfo`.
+      summary: Get using a valid api key to request the JWKSet
       description: >-
-        Return the current valid public keys used to encrypt JWTs issued by the service as a JSON Web Key Set
+        Returns the current valid public keys used to encrypt JWTs issued by the service as a JSON Web Key Set
       tags:
         - Backend - Passport CRI specific
       responses:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -11,6 +11,7 @@ Metadata:
         - E3020
         - W8003
         - E3031
+        - E3033
 
 Parameters:
   VpcStackName:
@@ -830,6 +831,31 @@ Resources:
     Properties:
       AliasName: !Sub alias/${AWS::StackName}/auditEventQueueEncryptionKey
       TargetKeyId: !Ref MockAuditEventQueueEncryptionKey
+
+  JWKSBucketRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: "sts:AssumeRole"
+            Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+        Version: 2012-10-17
+      Policies:
+        - PolicyName: AccessJWKSjson
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:Get*"
+                Resource:
+                  - !Sub "arn:aws:s3:::passport-${Environment}-key-rotation-bucket/jwks.json"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
 
 ####################################################################
 #                                                                  #


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

### What changed

Specified /.well-known/jwks.json definition in the public.api template
JWKSBucketRole required to access the S3 bucket via the endpoint has been added to the lambda infrastructure template

### Why did it change

To allow Core Stub to retrieve the active public key for encryption as part of the passport pilot.  A /well-known/jwks endpoint has been configured in the passport CRI API.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1592](https://govukverify.atlassian.net/browse/LIME-1592)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
Rebase, address final comment + commits signed - smsgds


[LIME-1592]: https://govukverify.atlassian.net/browse/LIME-1592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ