### PR TITLE
LIME-1626 Add support for new ipv-core client id - "ipv-core-3rd-party-stubs"

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/Strategy.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/Strategy.java
@@ -17,6 +17,7 @@ public enum Strategy {
             case "ipv-core-stub-aws-build_3rdparty" -> UAT;
             case "ipv-core-stub-aws-prod_3rdparty" -> UAT;
             case "ipv-core-stub-pre-prod-aws-build" -> LIVE;
+            case "ipv-core-3rd-party-stubs" -> STUB; // Real ipv-core
             case "ipv-core" -> LIVE;
             default -> NO_CHANGE;
         };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Add support for new ipv-core client id - "ipv-core-3rd-party-stubs"

Fix pre-merge sam build step missing sam-version: "1.134.0" pinning

### Why did it change

ipv-core-3rd-party-stubs - To enable an IPV-Core end to end journey with CRI using third-party stubs

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1626](https://govukverify.atlassian.net/browse/LIME-1626)
- depends on https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/441

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1626]: https://govukverify.atlassian.net/browse/LIME-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ