### PR TITLE
IPS-1529: Add tag to passport role

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -856,6 +856,9 @@ Resources:
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
+      Tags:
+        - Key: "key_consumer_type"
+          Value: "use"
 
 ####################################################################
 #                                                                  #


### PR DESCRIPTION
### What changed

-  Add `key_consumer_type=use` tag to APIGW role

### Why did it change

- The bucket policy is conditional upon tags: https://github.com/govuk-one-login/ipv-cri-common-infrastructure/pull/109

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [IPS-1529](https://govukverify.atlassian.net/browse/IPS-1529)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[IPS-1529]: https://govukverify.atlassian.net/browse/IPS-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ