### PR TITLE
LIME-1630 OAuth Pilot | Alarm for alias-based decryption failure

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1034,6 +1034,30 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
+  CommonAPISessionLambdaAliasBasedDecryptionFailure:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-${Environment} - Passport - Session lambda alias-based decryption failure
+      AlarmDescription: !Sub Passport ${Environment} - Common API Session Lambda all aliases unavailable for decryption
+      ActionsEnabled: true
+      AlarmActions:
+        - !If [ IsProdEnvironment, !Ref AlarmTopicPassport, !ImportValue platform-alarm-critical-alert-topic ]
+      OKActions:
+        - !If [ IsProdEnvironment, !Ref AlarmTopicPassport, !ImportValue platform-alarm-critical-alert-topic ]
+      InsufficientDataActions: [ ]
+      MetricName: all_aliases_unavailable_for_decryption
+      Namespace: !Sub "${CriIdentifier}"
+      Statistic: Sum
+      Dimensions:
+        - Name: Service
+          Value: !Sub "${CriIdentifier}-session"
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
   CommonAPIAuthorizationLambdaConcurrencyThresholdReached:
     Type: AWS::CloudWatch::Alarm
     Properties:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Implement an alarm that alerts when no key alias available to the CRI matches the encryption key used to create the encrypted payload it received from a client (Core/Core Stub).

Metric has been added to session lambda (all_aliases_unavailable_for_decryption).

### What changed

- Alarm config added to template
- Thresholds are low given the critical nature of the failure
- Alarm state testing attached to the ticket

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1630](https://govukverify.atlassian.net/browse/LIME-1630)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1630]: https://govukverify.atlassian.net/browse/LIME-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ