### PR TITLE
IPS-1633: Update bucket name

### DIFF
--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -193,7 +193,7 @@ paths:
         credentials:
           Fn::GetAtt: [ "JWKSBucketRole", "Arn" ]
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/passport-${Environment}-key-rotation-bucket/jwks.json"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-passport-published-keys-${Environment}/jwks.json"
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -851,7 +851,7 @@ Resources:
                 Action:
                   - "s3:Get*"
                 Resource:
-                  - !Sub "arn:aws:s3:::passport-${Environment}-key-rotation-bucket/jwks.json"
+                  - !Sub "arn:aws:s3:::govuk-one-login-passport-published-keys-${Environment}/jwks.json"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary


### PR DESCRIPTION
### What changed

- Updated bucket name

### Why did it change

- Minimise probability of the bucket name being taken, as all S3 bucket names must be globally unique

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1633](https://govukverify.atlassian.net/browse/IPS-1633)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[IPS-1633]: https://govukverify.atlassian.net/browse/IPS-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ