### PR TITLE
LIME-1683 Update to CRI-Lib 5.2.1

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
@@ -595,10 +595,12 @@ public class PassportPageObject extends UniversalSteps {
     }
 
     public void assertInvalidValidToDateInErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidValidToDateErrorInSummary, 10);
         Assert.assertEquals(expectedText, InvalidValidToDateErrorInSummary.getText());
     }
 
     public void assertInvalidValidToDateOnField(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidValidToDateFieldError, 10);
         Assert.assertEquals(
                 expectedText, InvalidValidToDateFieldError.getText().trim().replace("\n", ""));
     }

--- a/acceptance-tests/src/test/resources/features/passport/English/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/English/Passport.feature
@@ -155,6 +155,7 @@ Feature: Passport Test
     And User re-enters passport number as <InvalidPassportNumber>
     When User clicks on continue
     And I assert the url path contains details
+    Then Proper error message for Could not find your details is displayed
     When User click on ‘prove your identity another way' Link
     Then I navigate to the passport verifiable issuer to check for a Valid response
     And JSON response should contain documentNumber 887766551 same as given passport

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
 		// cri_common_lib dependencies should match the ipv-cri-lib version
 		// Workaround until dependency resolution is fixed.
 		// ---------------------------------------------------------
-		cri_common_lib_version             : "4.0.0",
+		cri_common_lib_version             : "5.2.1",
 
 		// AWS SDK
 		aws_sdk_version                    : "2.30.16",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Update to CRI-Lib 5.2.1

### Why did it change

To bring in retries on getSessionByAccessToken

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1683](https://govukverify.atlassian.net/browse/LIME-1683)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1683]: https://govukverify.atlassian.net/browse/LIME-1683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ