### PR TITLE
LIME-1755 Bump upload-action-ecr and cosign version

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -51,10 +51,10 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v1.9.0'
+          cosign-release: 'v2.5.2'
 
       - name: Build, push traffic test image to ECR
-        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # pin@1.3.0
+        uses: govuk-one-login/devplatform-upload-action-ecr@224346cd422f5bdfb6b68d0f8e189e55354b2804 # pin@1.4.0
         with:
           artifact-bucket-name: ""
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_DEV }}

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -52,10 +52,10 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v1.9.0'
+          cosign-release: 'v2.5.2'
 
       - name: Build, push traffic test image to ECR
-        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # pin@1.3.0
+        uses: govuk-one-login/devplatform-upload-action-ecr@224346cd422f5bdfb6b68d0f8e189e55354b2804 # pin@1.4.0
         with:
           artifact-bucket-name: ""
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->


### What changed

GHA to use the latest version of the Cosign package as all older versions are now unsupported. Requires update of [devplatform-upload-action-ecr](https://github.com/govuk-one-login/devplatform-upload-action-ecr) package.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1755](https://govukverify.atlassian.net/browse/LIME-1755)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
