### PR TITLE
LIME-1717 - Removed Beta Banner tests which are no longer required

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportPageObject.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.cri.passport.acceptance_tests.pages.Headers.IPV_CORE_STUB;
-import static uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils.checkOkHttpResponseOnLink;
 
 public class PassportPageObject extends UniversalSteps {
 
@@ -116,24 +115,6 @@ public class PassportPageObject extends UniversalSteps {
 
     @FindBy(xpath = "//*[@id=\"main-content\"]/div/div/p")
     public WebElement pageDescriptionHeading;
-
-    @FindBy(xpath = "/html/body/div[2]/div/p/strong")
-    public WebElement betaBanner;
-
-    @FindBy(className = "govuk-phase-banner__text")
-    public WebElement betaBannerText;
-
-    @FindBy(xpath = "//*[@id=\"cookies-banner-main\"]/div[2]/button[2]")
-    public WebElement rejectAnalysisButton;
-
-    @FindBy(xpath = "//*[@id=\"cookies-rejected\"]/div[1]/div/div/p")
-    public WebElement rejectAnalysisActual;
-
-    @FindBy(xpath = "//*[@id=\"cookies-rejected\"]/div[1]/div/div/p/a")
-    public WebElement changeCookieButton;
-
-    @FindBy(xpath = "/html/head/link[1]")
-    public WebElement cookiePreference;
 
     @FindBy(className = "govuk-error-summary__title")
     public WebElement errorSummaryTitle;
@@ -342,34 +323,6 @@ public class PassportPageObject extends UniversalSteps {
     // ------------------
 
     // Should be seperate page
-
-    public void betaBanner() {
-        betaBanner.isDisplayed();
-    }
-
-    public void betaBannerSentence(String expectedText) {
-        Assert.assertEquals(expectedText, betaBannerText.getText());
-    }
-
-    public void rejectAnalysisCookie(String rejectAnalyticsBtn) {
-        Assert.assertEquals(rejectAnalyticsBtn, rejectAnalysisButton.getText());
-        rejectAnalysisButton.click();
-    }
-
-    public void rejectCookieSentence(String rejectAnalysisSentence) {
-        LOGGER.info("CookieSentence = " + rejectAnalysisActual.getText());
-        Assert.assertEquals(rejectAnalysisSentence, rejectAnalysisActual.getText());
-    }
-
-    public void AssertChangeCookieLink(String changeCookieLink) {
-        Assert.assertEquals(changeCookieLink, changeCookieButton.getText());
-        changeCookieButton.click();
-    }
-
-    public void AssertcookiePreferencePage() {
-        String changeCookiePageUrl = cookiePreference.getAttribute("href");
-        checkOkHttpResponseOnLink(changeCookiePageUrl);
-    }
 
     public void passportPageURLValidation(String path) {
         assertURLContains(path);

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/PassportStepDefs.java
@@ -103,38 +103,6 @@ public class PassportStepDefs extends PassportPageObject {
         navigateToPassportCRIOnTestEnv();
     }
 
-    @Given("I view the Beta banner")
-    public void iViewTheBetaBanner() {
-        betaBanner();
-    }
-
-    @Then("^the beta banner reads (.*)$")
-    public void betaBannerContainsText(String expectedText) {
-        betaBannerSentence(expectedText);
-    }
-
-    @And("^I select (.*) button$")
-    public void selectRejectAnalysisCookie(String rejectAnalyticsBtn) {
-        rejectAnalysisCookie(rejectAnalyticsBtn);
-    }
-
-    @Then("^I see the Reject Analytics sentence (.*)$")
-    public void
-            iSeeTheSenetenceYouVeRejectedAdditionalCookiesYouCanChangeYourCookieSettingsAtAnyTime(
-                    String rejectAnalysisSentence) {
-        rejectCookieSentence(rejectAnalysisSentence);
-    }
-
-    @And("^I select the link (.*)$")
-    public void iSelectTheChangeYourCookieSettingsLink(String changeCookieLink) {
-        AssertChangeCookieLink(changeCookieLink);
-    }
-
-    @Then("^I check the page to change cookie preferences opens$")
-    public void iCheckThePageToChangeCookiePreferencesOpens() {
-        AssertcookiePreferencePage();
-    }
-
     @When("^User Re-enters data as a (.*)$")
     public void userReInputsDataAsAPassportSubject(String passportSubject) {
         userReEntersDataAsPassportSubject(passportSubject);

--- a/acceptance-tests/src/test/resources/features/passport/English/Passport.feature
+++ b/acceptance-tests/src/test/resources/features/passport/English/Passport.feature
@@ -32,16 +32,6 @@ Feature: Passport Test
       | PassportSubject             | InvalidLastName |
       | PassportSubjectHappyKenneth | KYLE123         |
 
-  @build @staging @integration @smoke @stub @uat
-  Scenario: Beta Banner Reject Analytics
-    When I view the Beta banner
-    When the beta banner reads This is a new service – your feedback (opens in new tab) will help us to improve it.
-    And I select Reject analytics cookies button
-    Then I see the Reject Analytics sentence You’ve rejected additional cookies. You can change your cookie settings at any time.
-    And  I select the link change your cookie settings
-    Then I check the page to change cookie preferences opens
-    Then The test is complete and I close the driver
-
   @build @staging @integration @stub @uat
   Scenario Outline: Passport details page unhappy path with IncorrectPassportNumber
     Given User enters data as a <PassportSubject>


### PR DESCRIPTION
The Beta banner tests and cookie accept/ reject tests now sit within the FE Repo


## Proposed changes

### What changed

1 Test has been removed from the Passport.feature file

### Why did it change

This test is no longer required as it is covered on the FE Repo

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1717](https://govukverify.atlassian.net/browse/LIME-1717)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
Testing: 
All UI test passed locally against DEV
<img width="220" height="87" alt="image" src="https://github.com/user-attachments/assets/1fd4d2fd-1503-439e-bfe9-f0983cc33e92" />


[LIME-1717]: https://govukverify.atlassian.net/browse/LIME-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ