### PR TITLE
LIME-1826 - Correct base-dir not being set to the correct directory

### DIFF
--- a/.github/workflows/cleanup-pre-merge-stacks.yml
+++ b/.github/workflows/cleanup-pre-merge-stacks.yml
@@ -1,11 +1,11 @@
-name: Clean up stale preview deployments
-run-name: Delete stale preview deployments
+name: Clean up stale pre-merge deployments
+run-name: Delete stale pre-merge deployments
 
 on:
   workflow_dispatch:
   schedule:
-    # Every weekday at 10am (9am is used by pre-merge-cleanup - deletion rate limits)
-    - cron: "0 10 * * 1-5"
+    # Every weekday at 9am (10am is used by preview-cleanup - deletion rate limits)
+    - cron: "0 9 * * 1-5"
 
 permissions:
   id-token: write
@@ -25,15 +25,16 @@ jobs:
           role-to-assume: ${{ secrets.AWS_PRE_MERGE_ROLE_ARN }}
           aws-region: eu-west-2
 
-      - name: Get stale preview stacks
+      - name: Get stale pre-merge stacks
         uses: govuk-one-login/github-actions/sam/get-stale-stacks@main
         with:
-          threshold-days: 14
-          stack-name-filter: preview-ipv-cri-uk-passport-api
+          threshold-days: 1 # Pre-merge are short-lived test stacks
+          stack-name-filter: pre-merge
           stack-tag-filters: |
+            cri:component=ipv-cri-uk-passport-api
+            cri:stack-type=pre-merge
+            cri:application=Lime
             cri:deployment-source=github-actions
-            cri:stack-type=preview
-          description: preview
           env-var-name: STACKS
 
       - name: Delete stacks

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -28,29 +28,36 @@ jobs:
       group: build-development-${{ github.head_ref || github.ref_name }}
     outputs:
       sha_short: ${{ steps.vars.outputs.sha_short }}
+      repo_base_dir : ${{ steps.vars.outputs.repo_base_dir }}
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: zulu
+
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: wrapper
           cache-overwrite-existing: true
+
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Get stack name vars
+
+      - name: Get output variables
         id: vars
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "repo_base_dir=$(pwd)" >> $GITHUB_OUTPUT
+
       - name: Build SAM application
         uses: govuk-one-login/github-actions/sam/build-application@main
         id: build
         with:
           sam-version: "1.134.0"
+          base-dir: ${{ steps.vars.outputs.repo_base_dir }}
           template: infrastructure/lambda/template.yaml
           cache-name: ipv-cri-uk-passport-api-${{ steps.vars.outputs.sha_short }}
           pull-repository: true

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -89,7 +89,8 @@ jobs:
       - name: SAM build
         run: |
           mkdir out
-          sam build -t infrastructure/lambda/template.yaml -b out
+          chmod a+x gradlew
+          sam build -s "${GITHUB_WORKSPACE}" -t infrastructure/lambda/template.yaml -b out
 
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@v3.9

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -93,7 +93,8 @@ jobs:
       - name: SAM build
         run: |
           mkdir out
-          sam build -t infrastructure/lambda/template.yaml -b out
+          chmod a+x gradlew
+          sam build -s "${GITHUB_WORKSPACE}" -t infrastructure/lambda/template.yaml -b out
 
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@v3.9

--- a/.github/workflows/run-pre-merge-integration-tests.yml
+++ b/.github/workflows/run-pre-merge-integration-tests.yml
@@ -25,29 +25,36 @@ jobs:
       group: build-development-${{ github.head_ref || github.ref_name }}
     outputs:
       sha_short: ${{ steps.vars.outputs.sha_short }}
+      repo_base_dir : ${{ steps.vars.outputs.repo_base_dir }}
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: zulu
+
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: wrapper
           cache-overwrite-existing: true
+
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Get stack name vars
+
+      - name: Get output variables
         id: vars
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "repo_base_dir=$(pwd)" >> $GITHUB_OUTPUT
+
       - name: Build SAM application
         uses: govuk-one-login/github-actions/sam/build-application@main
         id: build
         with:
           sam-version: "1.134.0"
+          base-dir: ${{ steps.vars.outputs.repo_base_dir }}
           template: infrastructure/lambda/template.yaml
           cache-name: ipv-cri-uk-passport-api-${{ steps.vars.outputs.sha_short }}
           pull-repository: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+CURRENT_PATH="${PWD}"
+
 RED="\033[1;31m"
 GREEN="\033[1;32m"
 NOCOLOR="\033[0m"
@@ -29,7 +31,7 @@ echo -e "\tCriIdentifier SSM key ${GREEN}$cri_identifier${NOCOLOR}"
 
 ./gradlew clean
 sam validate -t infrastructure/lambda/template.yaml --config-env dev --lint
-sam build -t infrastructure/lambda/template.yaml --config-env dev
+sam build -s "$CURRENT_PATH" -t infrastructure/lambda/template.yaml --config-env dev
 sam deploy --stack-name "$stack_name" \
   --no-fail-on-empty-changeset \
   --no-confirm-changeset \
@@ -37,7 +39,7 @@ sam deploy --stack-name "$stack_name" \
   --region eu-west-2 \
   --capabilities CAPABILITY_IAM \
   --tags \
-  cri:component=ipv-cri-passport-api \
+  cri:component=ipv-cri-uk-passport-api \
   cri:stack-type=dev \
   cri:application=Lime \
   cri:deployment-source=manual \

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -463,7 +463,7 @@ Resources:
           - [!Ref CheckPassportFunctionCanaryErrors, !Ref CheckPassportFunctionCanary5xxErrors]
           - [!Ref AWS::NoValue]
       Runtime: java17
-      CodeUri: ../../lambdas/checkpassport
+      CodeUri: lambdas/checkpassport
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
@@ -591,7 +591,7 @@ Resources:
           - [!Ref IssueCredentialFunctionCanaryErrors, !Ref IssueCredentialFunctionCanary5xxErrors]
           - [!Ref AWS::NoValue]
       Runtime: java17
-      CodeUri: ../../lambdas/issuecredential
+      CodeUri: lambdas/issuecredential
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
@@ -692,7 +692,7 @@ Resources:
     Properties:
       Handler: uk.gov.di.ipv.cri.passport.certexpiryreminder.handler.CertExpiryReminderHandler::handleRequest
       Runtime: java17
-      CodeUri: ../../lambdas/certexpiryreminder
+      CodeUri: lambdas/certexpiryreminder
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-CertExpiryReminder"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Correct base-dir not being set to the correct directory

Fix pre-merge stacks being left around
Space out some actions steps to aid readablity
    
Rename Get stack name vars to Get output variables, as it is now doing more than just the short sha
Store the checked out repo location in the output repo_base_dir to enable providing a full path as base-dir in the sam build action

### Why did it change

Base-dir if not set defaults to the template location.
This leaves sam build unable to find gradlew expecting the template to be in the project root directory. sam build the fall back to using gradle from the system PATH.

pre-merge stacks had no cleanup action, so if the step to delete them failed they stay around.
Several step actions where very condensed leading to readability issues.
Renaming to make clear the step purpose.
repo_base_dir output capture needed as base-dir needs a valid path not a string that may need evaluated.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1826](https://govukverify.atlassian.net/browse/LIME-1826)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1826]: https://govukverify.atlassian.net/browse/LIME-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ