### PR TITLE
Lime 1811: Update Dynatrace OneAgent Layer to v1_311_51_20250331-143707.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -277,23 +277,16 @@
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
-        "is_verified": false,
-        "line_number": 179
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 185
+        "line_number": 184
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 193
+        "line_number": 192
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java": [
@@ -366,5 +359,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-29T16:09:35Z"
+  "generated_at": "2025-08-14T14:10:56Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -175,9 +175,8 @@ Globals:
         ENVIRONMENT: !Ref Environment
         PARAMETER_PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
     Layers:
-      - !Sub
-        - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}' # or NODEJS_LAYER or PYTHON_LAYER
-        - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+      # SEE https://github.com/govuk-one-login/observability-infrastructure/tree/main/lambdalayer
+      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
 
 Mappings:
   EnvironmentConfiguration:
@@ -1277,8 +1276,6 @@ Resources:
       AlarmDescription: !Sub "Errors returned from the CheckPassportFunction Lambda."
       MetricName: Errors
       Dimensions:
-        - Name: Resource
-          Value: !Sub "${AWS::StackName}-CheckPassportFunction:live"
         - Name: FunctionName
           Value: !Ref CheckPassportFunction
         - Name: ExecutedVersion
@@ -1334,8 +1331,6 @@ Resources:
       AlarmDescription: !Sub "Errors returned from the IssueCredentialFunction Lambda."
       MetricName: Errors
       Dimensions:
-        - Name: Resource
-          Value: !Sub "${AWS::StackName}-IssueCredentialFunction:live"
         - Name: FunctionName
           Value: !Ref IssueCredentialFunction
         - Name: ExecutedVersion


### PR DESCRIPTION
### What changed

Change Dynatrace OneAgent Layer arn to a version based path for Passport API.

### Why did it change

Dynatrace OneAgent Layer first needs to resolve to v1_311 before then updating the version to v1_311.

### Issue tracking

- [LIME-1811](https://govukverify.atlassian.net/browse/LIME-1811)


[LIME-1811]: https://govukverify.atlassian.net/browse/LIME-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ