### PR TITLE
LIME-1834 redirect cert expiry alarm away from di-2nd-line

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1241,9 +1241,9 @@ Resources:
       AlarmDescription: !Sub Passport ${Environment} HMPO certificate is close to expiry (expires within 28 days) see certificate catalogue in confluence for expiries and certificate names
       ActionsEnabled: true
       AlarmActions:
-        - !If [ IsProdEnvironment, !Ref AlarmTopicPassport, !ImportValue platform-alarm-critical-alert-topic ]
+        - !ImportValue platform-alarm-critical-alert-topic
       OKActions:
-        - !If [ IsProdEnvironment, !Ref AlarmTopicPassport, !ImportValue platform-alarm-critical-alert-topic ]
+        - !ImportValue platform-alarm-critical-alert-topic
       InsufficientDataActions: [ ]
       MetricName: hmpo_cert_expiry_metric
       Namespace: !Sub "${CriIdentifier}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Directed the prod cert expiry alarm away from di-2nd-line channel as this has been firing daily and producing pager duty notifications for a cert that will expire in 20+ days. This alarm would continue firing daily until the certs are rotated without this change taking place. 

Once the certs are rotated, consideration will be given to reverting this change or leaving as is. This has been noted in the cert rotation ticket scope for https://govukverify.atlassian.net/browse/LIME-1757. 

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1834](https://govukverify.atlassian.net/browse/LIME-1834)

Evidence in ticket

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1834]: https://govukverify.atlassian.net/browse/LIME-1834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ