### PR TITLE
LIME-1458 Add clean up GH workflow for manually deployed Passport dev stacks

### DIFF
--- a/.github/workflows/cleanup-manually-deployed-dev-stacks.yml
+++ b/.github/workflows/cleanup-manually-deployed-dev-stacks.yml
@@ -1,0 +1,44 @@
+name: Clean up stale manual deployments in dev
+run-name: Delete stale manual deployments in dev
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every weekday at 11am (9am & 10am are used by pre-merge and preview-cleanup respectively - deletion rate limits)
+    - cron: "0 11 * * 1-5"
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency: cleanup-dev-${{ github.head_ref || github.ref_name }}
+
+jobs:
+  delete-stacks:
+    name: Delete stale stacks
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PRE_MERGE_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Get stale manually deployed stacks
+        uses: govuk-one-login/github-actions/sam/get-stale-stacks@main
+        with:
+          threshold-days: 90
+          stack-tag-filters: |
+            cri:component=ipv-cri-uk-passport-api
+            cri:stack-type=dev
+            cri:application=Lime
+            cri:deployment-source=manual
+          env-var-name: STACKS
+
+      - name: Delete stacks
+        if: ${{ env.STACKS != null }}
+        uses: govuk-one-login/github-actions/sam/delete-stacks@main
+        with:
+          stack-names: ${{ env.STACKS }}
+          verbose: true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Add a workflow to remove aging stacks deployed manually in all Lime CRI dev environments

### What changed

added scheduled workflow that filters dev stacks with the following tags:
cri:component=ipv-cri-fraud-api \ cri:stack-type=dev \ cri:application=Lime \ cri:deployment-source=manual \

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1458](https://govukverify.atlassian.net/browse/LIME-1458)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1458]: https://govukverify.atlassian.net/browse/LIME-1458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ