### PR TITLE
LIME-1890: Add FMS tags for custom WAF policy for dev/build/staging only

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -244,49 +244,49 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 150
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 153
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 153
+        "line_number": 156
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 156
+        "line_number": 159
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 159
+        "line_number": 162
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 184
+        "line_number": 187
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 192
+        "line_number": 195
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java": [
@@ -359,5 +359,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-27T14:12:36Z"
+  "generated_at": "2025-09-25T15:29:02Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -93,12 +93,15 @@ Conditions:
   IsProdEnvironment: !Equals
     - !Ref Environment
     - production
-
   IsNotCRIDevEnv:
     Fn::Not:
       - Fn::Equals:
         - !Ref DevEnvironment
         - "cri-dev"
+  IsDevOrBuildOrStaging: !Or
+    - !Equals [ !Ref Environment, dev ]
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
   UsingCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -320,6 +323,9 @@ Resources:
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
         Type: REGIONAL
+      Tags:
+        FMSRegionalPolicy: !If [ IsDevOrBuildOrStaging, "false", "none" ]
+        CustomPolicy: !If [ IsDevOrBuildOrStaging, "true", "none" ]
 
   PublicUKPassportAPILogGroup:
     Type: AWS::Logs::LogGroup
@@ -401,6 +407,9 @@ Resources:
                       - Fn::ImportValue:
                           !Sub "${VpcStackName}-ExecuteApiGatewayEndpointId"
               - !Ref AWS::NoValue
+      Tags:
+        FMSRegionalPolicy: !If [ IsDevOrBuildOrStaging, "false", "none" ]
+        CustomPolicy: !If [ IsDevOrBuildOrStaging, "true", "none" ]
 
   PrivateUKPassportAPILogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-1890] PR Title` -->

## Proposed changes

### What changed
Adding FMS tags for public and private api gateways in dev/build/staging.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
To move these resources from the generic Web ACL into the custom one.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1890](https://govukverify.atlassian.net/browse/LIME-1890)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->

See evidence in comments on ticket.

[LIME-1890]: https://govukverify.atlassian.net/browse/LIME-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1890]: https://govukverify.atlassian.net/browse/LIME-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ