### PR TITLE
LIME-1893 Add FMS tags for custom WAF policy

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -244,49 +244,49 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 146
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 153
+        "line_number": 149
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 156
+        "line_number": 152
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 159
+        "line_number": 155
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 162
+        "line_number": 158
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 187
+        "line_number": 183
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 195
+        "line_number": 191
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java": [
@@ -359,5 +359,5 @@
       }
     ]
   },
-  "generated_at": "2025-09-25T15:29:02Z"
+  "generated_at": "2025-10-06T14:41:15Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -98,10 +98,6 @@ Conditions:
       - Fn::Equals:
         - !Ref DevEnvironment
         - "cri-dev"
-  IsDevOrBuildOrStaging: !Or
-    - !Equals [ !Ref Environment, dev ]
-    - !Equals [ !Ref Environment, build ]
-    - !Equals [ !Ref Environment, staging ]
   UsingCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -324,8 +320,8 @@ Resources:
       EndpointConfiguration:
         Type: REGIONAL
       Tags:
-        FMSRegionalPolicy: !If [ IsDevOrBuildOrStaging, "false", "none" ]
-        CustomPolicy: !If [ IsDevOrBuildOrStaging, "true", "none" ]
+        FMSRegionalPolicy: "false"
+        CustomPolicy: "true"
 
   PublicUKPassportAPILogGroup:
     Type: AWS::Logs::LogGroup
@@ -408,8 +404,8 @@ Resources:
                           !Sub "${VpcStackName}-ExecuteApiGatewayEndpointId"
               - !Ref AWS::NoValue
       Tags:
-        FMSRegionalPolicy: !If [ IsDevOrBuildOrStaging, "false", "none" ]
-        CustomPolicy: !If [ IsDevOrBuildOrStaging, "true", "none" ]
+        FMSRegionalPolicy: "false"
+        CustomPolicy: "true"
 
   PrivateUKPassportAPILogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Adding FMS tags for public and private api gateways in all environments
Removing conditional for dev/build/staging.

### Why did it change

To move these resources from the generic Web ACL into the custom one.

Testing for dev through to staging was successful

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1893](https://govukverify.atlassian.net/browse/LIME-1893)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1893]: https://govukverify.atlassian.net/browse/LIME-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ