### PR TITLE
LIME-2034 Increase number of traffic test suite iterations to match the deployment duration

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -16,7 +16,7 @@ if [ "$TRAFFIC_TEST" = "true" ]; then
   # It must not run beyond the stack deploy duration,
   # or will be running at the same time as the AC test suite.
   # Leading to the smaller dev F.E containers getting overwhelmed.
-  TEST_RUNS=3
+  TEST_RUNS=6
   CUCUMBER_SSM_PARAMETER="TrafficTestTag"
   echo "Traffic Test selected with ${TEST_RUNS} iterations"
 fi


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Increase number of traffic test suite iterations to match the deployment duration

### Why did it change

Traffic test finished before the canaries started

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2034](https://govukverify.atlassian.net/browse/LIME-2034)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2034]: https://govukverify.atlassian.net/browse/LIME-2034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ