### PR TITLE
LIME-2171 - Added ObjectMapperFactory utility

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,84 +133,84 @@
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "b35d40d12423628d17dba54252182396a1d90103",
         "is_verified": false,
-        "line_number": 476
+        "line_number": 475
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "7d46dde65b8301c1eaf84f99441a92be55bcf5f1",
         "is_verified": false,
-        "line_number": 477
+        "line_number": 476
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "a24621f1e7f2aa3be1b3fd8aa158bb666fef7da0",
         "is_verified": false,
-        "line_number": 481
+        "line_number": 480
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "acdb3814fc474a0eff4b8a0c471dd3d588409995",
         "is_verified": false,
-        "line_number": 482
+        "line_number": 481
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "fe2031f80d50c6fe6902a22233162a77f5e72952",
         "is_verified": false,
-        "line_number": 486
+        "line_number": 485
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "bd51a1e663fbdda216f4a0af85e7889b1a7acae6",
         "is_verified": false,
-        "line_number": 488
+        "line_number": 487
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "4189dcfc39ca9e23b297ffbbae6f8fc2065e385f",
         "is_verified": false,
-        "line_number": 489
+        "line_number": 488
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "83d2570a5fba078cbc5d2d6167a3c95b096222aa",
         "is_verified": false,
-        "line_number": 494
+        "line_number": 493
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "3f80e3787a4e138a7d4dc0ded3f5523bdfe65af3",
         "is_verified": false,
-        "line_number": 495
+        "line_number": 494
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "7c186605d87b2294f2353966611a68619729a9f3",
         "is_verified": false,
-        "line_number": 499
+        "line_number": 498
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "180a11b0b86b1a47d9fd1caf3a38e217f8585958",
         "is_verified": false,
-        "line_number": 500
+        "line_number": 499
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java",
         "hashed_secret": "c29bfc272e1012aacc9dcad023af303f34e8b08a",
         "is_verified": false,
-        "line_number": 501
+        "line_number": 500
       }
     ],
     "acceptance-tests/src/test/resources/axe.min.js": [
@@ -359,5 +359,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-22T13:26:58Z"
+  "generated_at": "2026-05-05T11:28:46Z"
 }

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -25,8 +25,7 @@ dependencies {
 			libs.nimbus.oauth,
 			platform(libs.junit.platform.bom),
 			libs.bundles.unit.testing,
-			libs.aws.cdk.lib,
-			"org.json:json:20250517" // Migration to jackson only in progress - DO not use org.json in new code
+			libs.aws.cdk.lib
 
 	implementation libs.bundles.actest.cucumber
 

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PassportAPIPage.java
@@ -5,10 +5,8 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONObject;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +14,7 @@ import uk.gov.di.ipv.cri.passport.acceptance_tests.model.AuthorisationResponse;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.model.CheckPassportSuccessResponse;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.model.PassportFormData;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.service.ConfigurationService;
+import uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.ObjectMapperFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,8 +49,7 @@ public class PassportAPIPage extends CommonPageObject {
     private static String vcBody;
     private static final String KID_PREFIX = "did:web:review-p.dev.account.gov.uk#";
     private static String retry;
-    private static final ObjectMapper OBJECT_MAPPER =
-            new ObjectMapper().registerModule(new JavaTimeModule());
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.MAPPER;
 
     private final ConfigurationService configurationService =
             new ConfigurationService(System.getenv("ENVIRONMENT"));
@@ -408,9 +406,9 @@ public class PassportAPIPage extends CommonPageObject {
         vcBody = signedJWT.getJWTClaimsSet().toString();
         LOGGER.info("VC Body = {}", vcBody);
 
-        JSONObject jsonHeader;
+        JsonNode jsonHeader;
         try {
-            jsonHeader = new JSONObject(vcHeader);
+            jsonHeader = OBJECT_MAPPER.readTree(vcHeader);
         } catch (Exception e) {
             LOGGER.error("Failed to parse VC Header as JSON", e);
             throw new AssertionError("Failed to parse VC Header as JSON", e);
@@ -423,12 +421,12 @@ public class PassportAPIPage extends CommonPageObject {
         Assert.assertEquals(
                 "The 'typ' field does not have the expected value",
                 "JWT",
-                jsonHeader.getString("typ"));
+                jsonHeader.get("typ").asText());
         Assert.assertEquals(
                 "The 'alg' field does not have the expected value",
                 "ES256",
-                jsonHeader.getString("alg"));
-        String kid = jsonHeader.getString("kid");
+                jsonHeader.get("alg").asText());
+        String kid = jsonHeader.get("kid").asText();
         Assert.assertTrue(
                 "The 'kid' field does not start with the expected prefix",
                 kid.startsWith(KID_PREFIX));

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/UniversalSteps.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/UniversalSteps.java
@@ -1,10 +1,11 @@
 package uk.gov.di.ipv.cri.passport.acceptance_tests.pages;
 
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.openqa.selenium.support.PageFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.Driver;
+import uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.ObjectMapperFactory;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -16,6 +17,7 @@ import static uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils
 public class UniversalSteps {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UniversalSteps.class);
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.MAPPER;
 
     public static final int MAX_WAIT_SEC = 15;
 
@@ -55,8 +57,7 @@ public class UniversalSteps {
         String filePath = "src/test/resources/Data/" + fileName + ".json";
         try {
             String content = new String(Files.readAllBytes(Paths.get(filePath)));
-            JSONObject jsonObject = new JSONObject(content);
-            return jsonObject.toString();
+            return OBJECT_MAPPER.readTree(content).toString();
         } catch (Exception e) {
             e.printStackTrace();
             return null;

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/ObjectMapperFactory.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/ObjectMapperFactory.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public class ObjectMapperFactory {
-    public static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+    public static final ObjectMapper MAPPER =
+            new ObjectMapper().registerModule(new JavaTimeModule());
 
     private ObjectMapperFactory() {}
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/ObjectMapperFactory.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/utilities/ObjectMapperFactory.java
@@ -1,0 +1,10 @@
+package uk.gov.di.ipv.cri.passport.acceptance_tests.utilities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class ObjectMapperFactory {
+    public static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private ObjectMapperFactory() {}
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Added ObjectMapperFactory utility in the utilities file Refactored UniversalSepts and PassportAPIPage, removed import org.json.JSONObject and replaced with shared object mapper

### Why did it change

To improve maintainability and align with Fraud BE Config

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2171](https://govukverify.atlassian.net/browse/LIME-2171)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2171]: https://govukverify.atlassian.net/browse/LIME-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="292" height="83" alt="image" src="https://github.com/user-attachments/assets/9685b5a6-f6c9-400e-8def-0e1d057514db" />
