### PR TITLE
BAU: Updating actions running on node 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,7 +55,7 @@ updates:
     commit-message:
       prefix: BAU
     groups:
-      pre-commit-hooks:
+      docker:
         patterns:
           - "*"
 
@@ -65,13 +65,16 @@ updates:
       interval: weekly
       day: monday
       time: "03:00"
+    ignore:
+      - dependency-name: "gradle/actions/setup-gradle"
+        versions: ["6.x"] # v6 contains updates to terms which we need to understand and review
     target-branch: main
     labels:
       - dependabot
     commit-message:
       prefix: BAU
     groups:
-      pre-commit-hooks:
+      actions:
         patterns:
           - "*"
 

--- a/.github/workflows/delete-preview-stacks.yml
+++ b/.github/workflows/delete-preview-stacks.yml
@@ -29,7 +29,7 @@ jobs:
           verbose: false
 
       - name: Delete stack
-        uses: govuk-one-login/github-actions/sam/delete-stacks@3b0015c58dd0e19e1572fda59dda4184df387d1e
+        uses: govuk-one-login/github-actions/sam/delete-stacks@2518d831abb4ec03fa3125619507f932966f2833
         with:
           stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
           aws-role-arn: ${{ secrets.AWS_PRE_MERGE_ROLE_ARN }}

--- a/.github/workflows/delete-stale-log-groups.yml
+++ b/.github/workflows/delete-stale-log-groups.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: govuk-one-login/github-actions/sam/delete-stale-log-groups@3b0015c58dd0e19e1572fda59dda4184df387d1e
+      - uses: govuk-one-login/github-actions/sam/delete-stale-log-groups@8d9b70ea03249a138db2b04c02071d7826cb00d9
         with:
           aws-role-arn: ${{ secrets.AWS_PRE_MERGE_ROLE_ARN }}
           cutoff-days: "30"

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -34,7 +34,7 @@ jobs:
           cache-overwrite-existing: true
 
       - name: Setup SAM
-        uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133 # v2
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
           version: "1.157.1"
@@ -91,7 +91,7 @@ jobs:
           sam build -s "${GITHUB_WORKSPACE}" -t infrastructure/lambda/template.yaml -b out
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@b7bc01ed6e0b61d54f42e7f3d12dd3fdbb0f172a # v3.13.0
+        uses: govuk-one-login/devplatform-upload-action@245bad4dc21702a5e665f1ca615108f6e70546d2 # v4.0.0
         with:
           artifact-bucket-name: "${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.DEV_SIGNING_PROFILE_NAME }}"

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -33,7 +33,7 @@ jobs:
           cache-overwrite-existing: true
 
       - name: Setup SAM
-        uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133 # v2
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
           version: "1.157.1"
@@ -94,7 +94,7 @@ jobs:
           sam build -s "${GITHUB_WORKSPACE}" -t infrastructure/lambda/template.yaml -b out
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@b7bc01ed6e0b61d54f42e7f3d12dd3fdbb0f172a # v3.13.0
+        uses: govuk-one-login/devplatform-upload-action@245bad4dc21702a5e665f1ca615108f6e70546d2 # v4.0.0
         with:
           artifact-bucket-name: "${{ secrets.ARTIFACT_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.SIGNING_PROFILE_NAME }}"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed
Updating actions running on node 20

Also some small dependabot updates:
- fix groupings
- ignore setup gradle v6 updates due to changes in terms of use that need review
  - see https://blog.gradle.org/github-actions-for-gradle-v6

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Actions are forced to run on node 24 from 02/06, so its worth updating them where we can to avoid unusual or unexpected behaviour.
There was also naming mistakes from the last PR for dependabot config groupings.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
BAU

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
