### PR TITLE
LIME-2213: Update cri_common_lib to 9.0.1, limeade to 1.2.2, and opentelemetry_bom_alpha to 2.28.1-alpha and remove deprecated feature flags.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -295,14 +295,14 @@
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java",
         "hashed_secret": "41c5ebe18c2f4a118ee2798dca00c8ca2f981149",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 139
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java",
         "hashed_secret": "3e4372459809fa2f4f46af84291360a04ead6573",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 140
       }
     ],
     "lib/src/testFixtures/java/uk/gov/di/ipv/cri/passport/library/CertAndKeyTestFixtures.java": [
@@ -359,5 +359,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-06T19:48:35Z"
+  "generated_at": "2026-06-08T12:16:21Z"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,8 @@ post_compile_weaving = "9.2.0"
 aws_sdk = "2.42.31"
 aws_lambda_events = "3.16.0"
 aws_lambda_core = "1.4.0" # https://github.com/aws/aws-lambda-java-libs
-cri_common_lib = "8.3.4"
-limeade = "1.1.1"
+cri_common_lib = "9.0.1"
+limeade = "1.2.2"
 nimbusds_oauth = "11.37"
 aspect_jrt = "1.9.25.1"
 aws_powertools = "2.10.0"
@@ -21,7 +21,7 @@ apache_httpcomponents_httpcore = "4.4.16"
 apache_httpcomponents_httpclient = "4.5.14"
 
 # Lambdas OpenTel
-opentelemetry_bom_alpha = "2.20.1-alpha"
+opentelemetry_bom_alpha = "2.28.1-alpha"
 
 # Unit tests
 junit = "6.0.3"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -247,24 +247,14 @@ Mappings:
 
   FeatureFlagMapping:
     dev:
-      VcExpiryRemoved: "true"
-      VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "true"
     build:
-      VcExpiryRemoved: "true"
-      VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
     staging:
-      VcExpiryRemoved: "true"
-      VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
     integration:
-      VcExpiryRemoved: "true"
-      VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
     production:
-      VcExpiryRemoved: "true"
-      VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
 
 Resources:
@@ -600,8 +590,6 @@ Resources:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-issuecredential"
           ENVIRONMENT: !Ref Environment
-          ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED: !FindInMap [ FeatureFlagMapping, !Ref Environment, VcExpiryRemoved ]
-          ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID: !FindInMap [ FeatureFlagMapping, !Ref Environment, VcContainsUniqueIdMapping ]
           INCLUDE_VC_KID: !FindInMap [ FeatureFlagMapping, !Ref Environment, IncludeKidInVc ]
           SESSION_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
           VERIFIABLE_CREDENTIAL_ISSUER: !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"
@@ -645,7 +633,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
                 - !Sub
                   - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/release-flags/vc-contains-unique-id"
-                  - PREFIX: !If [IsDeployedFromPipeline, !Ref AWS::StackName , !Ref AWS::StackName]
+                  - PREFIX: !If [ IsDeployedFromPipeline, !Ref AWS::StackName , !Ref AWS::StackName ]
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/JwtTtlUnit"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaxJwtTtl"

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/pact/IssueCredentialHandlerTest.java
@@ -73,8 +73,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID;
-import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED;
 import static uk.gov.di.ipv.cri.passport.library.config.ParameterStoreParameters.MAX_JWT_TTL_UNIT;
 
 @Tag("Pact")
@@ -128,8 +126,6 @@ class IssueCredentialHandlerTest {
     void pactSetup(PactVerificationContext context)
             throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
 
-        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED, true);
-        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, true);
         environmentVariables.set("INCLUDE_VC_KID", false);
         environmentVariables.set("POWERTOOLS_METRICS_NAMESPACE", "StackName");
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/service/VerifiableCredentialServiceTest.java
@@ -191,9 +191,8 @@ class VerifiableCredentialServiceTest implements VerifiableCredentialServiceTest
 
         assertEquals(UNIT_TEST_SUBJECT, claimsSet.get("sub").textValue());
         assertEquals(UNIT_TEST_VC_ISSUER, claimsSet.get("iss").textValue());
-        long notBeforeTime = claimsSet.get("nbf").asLong();
-        final long expirationTime = claimsSet.get("exp").asLong();
-        assertEquals(TTL, expirationTime - notBeforeTime);
+        assertNotNull(claimsSet.get("nbf"));
+        assertTrue(claimsSet.get("nbf").asLong() > 0);
 
         // VC Type
         assertEquals(


### PR DESCRIPTION
## Proposed changes

### What changed

- CRI Common Lib upgrade to 9.0.1
- Limeade updated to 1.2.2
- Open tel updated to 2.28.1-alpha

### Why did it change

- As part of Dependabot updates 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2213](https://govukverify.atlassian.net/browse/LIME-2213)

[LIME-2213]: https://govukverify.atlassian.net/browse/LIME-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ