### PR TITLE
LIME-2213: Remove SSM param permissions for deprecated feature flags.

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -630,10 +630,6 @@ Resources:
               Action:
                 - ssm:GetParameter
               Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
-                - !Sub
-                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/release-flags/vc-contains-unique-id"
-                  - PREFIX: !If [ IsDeployedFromPipeline, !Ref AWS::StackName , !Ref AWS::StackName ]
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/JwtTtlUnit"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaxJwtTtl"


### PR DESCRIPTION
## Proposed changes

### What changed

- Remove `ssm:GetParameter` permissions for `vc-expiry-removed` and `vc-contains-unique-id`

### Why did it change

- Follow up clean up PR for removing the deprecated feature flags as part of cri lib update

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2213](https://govukverify.atlassian.net/browse/LIME-2213)

[LIME-2213]: https://govukverify.atlassian.net/browse/LIME-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ