### PR TITLE
LIME-2229: Upgrade jackson and jackson_jr to 2.21.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,8 +13,8 @@ limeade = "1.2.2"
 nimbusds_oauth = "11.37"
 aspect_jrt = "1.9.25.1"
 aws_powertools = "2.10.0"
-jackson = "2.21.2"
-jackson_jr = "2.21.2"
+jackson = "2.21.4"
+jackson_jr = "2.21.4"
 
 # Lambdas Apache HTTP Client https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/dependencies.html
 apache_httpcomponents_httpcore = "4.4.16"


### PR DESCRIPTION
## Proposed changes

### What changed

- Upgrade `jackson` and `jackson_jr` from `2.21.2` to `2.21.4`

### Why did it change

- Dependabot

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2229](https://govukverify.atlassian.net/browse/LIME-2229)

### Other considerations



[LIME-2229]: https://govukverify.atlassian.net/browse/LIME-2229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ